### PR TITLE
Get rid of StringIO altogether

### DIFF
--- a/iminuit/tests/test_describe.py
+++ b/iminuit/tests/test_describe.py
@@ -8,7 +8,7 @@ def f(x,y):
     pass
 
 def test_simple():
-    assert_equal(describe(f,True), ['x','y'])
+    assert_equal(describe(f, True), ['x','y'])
 
 #test bound method
 class A:
@@ -17,11 +17,11 @@ class A:
 
 def test_bound():
     a=A()
-    assert_equal(describe(a.f,True),['x','y'])
+    assert_equal(describe(a.f, True),['x','y'])
 
 #unbound method
 def test_unbound():
-    assert_equal(describe(A.f,True),['self','x','y'])
+    assert_equal(describe(A.f, True),['self','x','y'])
 
 #faking func code
 class Func_Code:
@@ -38,7 +38,7 @@ class Func1:
 
 def test_call():
     f1 = Func1()
-    assert_equal(describe(f1,True),['x','y'])
+    assert_equal(describe(f1, True),['x','y'])
 
 #fake func
 class Func2:
@@ -49,10 +49,10 @@ class Func2:
 
 def test_fakefunc():
     f2 = Func2()
-    assert_equal(describe(f2,True),['x','y'])
+    assert_equal(describe(f2, True),['x','y'])
 
 #builtin (parsing doc)
 def test_builtin():
-    assert_equal(describe(min),['iterable','key'])
+    assert_equal(describe(min, True),['iterable','key'])
 
 # TODO: any good way to test cython builtin call?

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -3,7 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import inspect
-from io import StringIO
 import re
 
 __all__ = [
@@ -53,14 +52,17 @@ def arguments_from_docstring(doc):
     It can also parse cython docstring of the form
     ``Minuit.migrad(self[, int ncall_me =10000, resume=True, int nsplit=1])``
     """
+
     if doc is None:
         raise RuntimeError('__doc__ is None')
-    sio = StringIO.StringIO(doc.lstrip())
+
+    doc = doc.lstrip()
+
     #care only the firstline
     #docstring can be long
-    line = sio.readline()
+    line = doc.split('\n', 1)[0] #get the firstline
     if line.startswith("('...',)"):
-        line=sio.readline()#stupid cython
+        line = doc.split('\n', 2)[1] #get the second line
     p = re.compile(r'^[\w|\s.]+\(([^)]*)\).*')
     #'min(iterable[, key=func])\n' -> 'iterable[, key=func]'
     sig = p.search(line)


### PR DESCRIPTION
Make python 2 and python 3 compatibility much easier to achieve.