### PR TITLE
Use general format for parameter printout in place of exponent notation

### DIFF
--- a/iminuit/frontends/html.py
+++ b/iminuit/frontends/html.py
@@ -162,7 +162,7 @@ class HtmlFrontend:
             *merr* : minos error
             *float_format* : control the format of latex floating point output
                 default '%5.3e'
-            *smart_latex* : convert greek symbols and underscores to latex 
+            *smart_latex* : convert greek symbols and underscores to latex
                 symbol. default True
         """
         to_print = ""
@@ -193,10 +193,10 @@ class HtmlFrontend:
             <tr>
                 <td>{j}</td>
                 <td>{mp.name}</td>
-                <td>{mp.value:e}</td>
-                <td>{mp.error:e}</td>
-                <td>{minos_m:e}</td>
-                <td>{minos_p:e}</td>
+                <td>{mp.value:g}</td>
+                <td>{mp.error:g}</td>
+                <td>{minos_m:g}</td>
+                <td>{minos_p:g}</td>
                 <td>{limit_m!s}</td>
                 <td>{limit_p!s}</td>
                 <td>{fixed}</td>


### PR DESCRIPTION
I've modified the HTML printout a little bit. This is an example from the tutorial.

Before:
<img width="615" alt="bildschirmfoto 2015-08-20 um 12 40 38" src="https://cloud.githubusercontent.com/assets/13285808/9384554/91647b46-4751-11e5-97fe-fbf45234cc58.png">

After:
<img width="568" alt="bildschirmfoto 2015-08-20 um 12 40 54" src="https://cloud.githubusercontent.com/assets/13285808/9384562/99167b82-4751-11e5-8a1c-163c60560e53.png">

I think it looks cleaner. What do you think?