### PR TITLE
Use setuptools and pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ _libiminuit.cpp
 
 .ipynb_checkpoints
 iminuit.egg-info
+
+htmlcov
+
+.eggs
+env

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ htmlcov
 
 .eggs
 env
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 build
 *.pyc
 .idea
+.cache
 _build
 archive
 html

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ matrix:
 
 before_install:
   - pip install setuptools Cython
-  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib coverage; fi
+  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
+  - if [[ $BUILD == TEST ]]; then pip install pytest pytest-cov; fi
 
 install:
   - python setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - python setup.py build_ext -i
 
 script:
-  - if [[ $BUILD == TEST ]]; then nosetests -v; fi
+  - if [[ $BUILD == TEST ]]; then py.test -v iminuit; fi
   - if [[ $BUILD == COVERAGE ]]; then python setup.py coverage; fi
   # TODO: add -W option to Sphinx build once this Sphinx bug is fixed:
   # https://github.com/iminuit/iminuit/pull/132#issuecomment-62139507

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ install:
   - python setup.py build_ext -i
 
 script:
-  - if [[ $BUILD == TEST ]]; then python -m pytest -v iminuit; fi
-  - if [[ $BUILD == COVERAGE ]]; then python -m pytest -v iminuit --cov iminuit --cov-report html; fi
+  - if [[ $BUILD == TEST ]]; then make test; fi
+  - if [[ $BUILD == COVERAGE ]]; then make coverage; fi
   # TODO: add -W option to Sphinx build once this Sphinx bug is fixed:
   # https://github.com/iminuit/iminuit/pull/132#issuecomment-62139507
   - if [[ $BUILD == DOCS ]]; then cd doc; sphinx-build -a -E -b html -d _build/doctrees . _build/html; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
 
         # TODO: add tests for installed version!!
 
+        # TODO: add tests on Mac
+
+        # TODO: add tests for Python from conda
+
         - python: 2.7
           env: BUILD=DOCS
 
@@ -32,7 +36,7 @@ before_install:
   - pip install setuptools Cython
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
-  - if [[ $BUILD == TEST ]]; then pip install pytest pytest-cov; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi
 
 install:
   - python setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,35 @@
 language: python
 
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-
-cache:
-  directories:
-    - $HOME/.cache/pip
-
 sudo: false
-
-env:
-    global:
-        - BUILD=TEST
-        # TODO: add test with / without running cython
 
 matrix:
     include:
-        # Extra build to make sure that `iminuit` works without the optional dependencies
         - python: 2.7
-          env: BUILD=NO_EXTRA_DEPS
+          env: BUILD=TEST
 
-        # Extra build to make sure that the docs build without errors or warnings
+        - python: 3.4
+          env: BUILD=TEST
+
+        - python: 3.5
+          env: BUILD=TEST
+
+        # TODO: add tests for installed version!!
+
         - python: 2.7
+          env: BUILD=DOCS
+
+        - python: 3.4
           env: BUILD=DOCS
 
         - python: 3.5
           env: BUILD='COVERAGE'
 
-        # Extra build to compute coverage
-        - python: 2.7
-          env: BUILD='COVERAGE'
+        - python: 3.5
+          env: BUILD=NO_EXTRA_DEPS
+
 
 before_install:
-  - pip install Cython
+  - pip install setuptools Cython
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib coverage; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
 
@@ -42,8 +37,8 @@ install:
   - python setup.py build_ext -i
 
 script:
-  - if [[ $BUILD == TEST ]]; then py.test -v iminuit; fi
-  - if [[ $BUILD == COVERAGE ]]; then python setup.py coverage; fi
+  - if [[ $BUILD == TEST ]]; then python -m pytest -v iminuit; fi
+  - if [[ $BUILD == COVERAGE ]]; then python -m pytest -v iminuit --cov iminuit --cov-report html; fi
   # TODO: add -W option to Sphinx build once this Sphinx bug is fixed:
   # https://github.com/iminuit/iminuit/pull/132#issuecomment-62139507
   - if [[ $BUILD == DOCS ]]; then cd doc; sphinx-build -a -E -b html -d _build/doctrees . _build/html; fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ recursive-include Minuit *
 include *.py
 include README.rst
 include LICENSE
+include iminuit/tests/cyfunc.pyx
+include iminuit/tests/cyfunc.pyxbld

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+# Makefile with some convenient quick ways to do common things
+
+PROJECT = iminuit
+CYTHON ?= cython
+
+help:
+	@echo ''
+	@echo ' iminuit available make targets:'
+	@echo ''
+	@echo '     help             Print this help message (the default)'
+	@echo ''
+	@echo '     doc-show         Open local HTML docs in browser'
+	@echo '     clean            Remove generated files'
+	@echo '     clean-repo       Remove all untracked files and directories (use with care!)'
+	@echo '     cython           Compile cython files'
+	@echo ''
+	@echo '     trailing-spaces  Remove trailing spaces at the end of lines in *.py files'
+	@echo '     code-analysis    Run code analysis (flake8 and pylint)'
+	@echo '     flake8           Run code analysis (flake8)'
+	@echo '     pylint           Run code analysis (pylint)'
+	@echo ''
+	@echo ' Note that most things are done via `python setup.py`, we only use'
+	@echo ' make for things that are not trivial to execute via `setup.py`.'
+	@echo ''
+	@echo ' Common `setup.py` commands:'
+	@echo ''
+	@echo '     python setup.py --help-commands'
+	@echo '     python setup.py install'
+	@echo '     python setup.py develop'
+	@echo '     python setup.py test -V'
+	@echo '     python setup.py test --help # to see available options'
+	@echo '     python setup.py build_sphinx # use `-l` for clean build'
+	@echo ''
+	@echo ' More info:'
+	@echo ''
+	@echo ' * iminuit code: https://github.com/iminuit/iminuit'
+	@echo ' * iminuit docs: https://iminuit.readthedocs.org/'
+	@echo ''
+
+clean:
+	rm -rf build
+	find . -name "*.pyc" -exec rm {} \;
+	find . -name "*.so" -exec rm {} \;
+	find . -name __pycache__ | xargs rm -fr
+
+clean-repo:
+	@git clean -f -x -d
+
+test:
+	python setup.py build_ext --inplace
+	python -m pytest -v iminuit
+
+coverage:
+	python setup.py build_ext --inplace
+	python -m pytest -v iminuit --cov iminuit --cov-report html
+
+cython:
+	find $(PROJECT) -name "*.pyx" -exec $(CYTHON) {} \;
+
+trailing-spaces:
+	find $(PROJECT) examples docs -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
+
+code-analysis: flake8 pylint
+
+flake8:
+	flake8 $(PROJECT) | grep -v __init__ | grep -v external
+
+# TODO: once the errors are fixed, remove the -E option and tackle the warnings
+pylint:
+	pylint -E $(PROJECT)/ -d E1103,E0611,E1101 \
+	       --ignore=_astropy_init.py -f colorized \
+	       --msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})'
+
+doc-show:
+	open build/sphinx/html/index.html

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,8 @@ help:
 	@echo ''
 	@echo '     doc-show         Open local HTML docs in browser'
 	@echo '     clean            Remove generated files'
-	@echo '     clean-repo       Remove all untracked files and directories (use with care!)'
 	@echo '     cython           Compile cython files'
 	@echo ''
-	@echo '     trailing-spaces  Remove trailing spaces at the end of lines in *.py files'
 	@echo '     code-analysis    Run code analysis (flake8 and pylint)'
 	@echo '     flake8           Run code analysis (flake8)'
 	@echo '     pylint           Run code analysis (pylint)'
@@ -38,33 +36,27 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build
+	rm -rf build htmlcov
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find . -name __pycache__ | xargs rm -fr
 
-clean-repo:
-	@git clean -f -x -d
-
-test:
+build:
 	python setup.py build_ext --inplace
+
+test: build
 	python -m pytest -v iminuit
 
-coverage:
-	python setup.py build_ext --inplace
-	python -m pytest -v iminuit --cov iminuit --cov-report html
+coverage: build
+	python -m pytest -v iminuit --cov iminuit --cov-report html --cov-report term-missing --cov-report xml
 
 cython:
-	find $(PROJECT) -name "*.pyx" -exec $(CYTHON) {} \;
-
-trailing-spaces:
-    # TODO: the perl command doesn't work on my Mac (Christoph).
-	find $(PROJECT) doc -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
+	find $(PROJECT) -name "*.pyx" -exec $(CYTHON) --cplus  {} \;
 
 code-analysis: flake8 pylint
 
 flake8:
-	flake8 $(PROJECT) | grep -v __init__ | grep -v external
+	flake8 --max-line-length=90 $(PROJECT) | grep -v __init__ | grep -v external
 
 # TODO: once the errors are fixed, remove the -E option and tackle the warnings
 pylint:

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,13 @@ help:
 	@echo ''
 	@echo '     help             Print this help message (the default)'
 	@echo ''
-	@echo '     doc-show         Open local HTML docs in browser'
 	@echo '     clean            Remove generated files'
+	@echo '     build            Build inplace'
+	@echo '     test             Run tests'
+	@echo '     coverage         Run tests and write coverage report'
 	@echo '     cython           Compile cython files'
+	@echo '     doc              Run Sphinx to generate HTML docs'
+	@echo '     doc-show         Open local HTML docs in browser'
 	@echo ''
 	@echo '     code-analysis    Run code analysis (flake8 and pylint)'
 	@echo '     flake8           Run code analysis (flake8)'
@@ -36,7 +40,7 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build htmlcov
+	rm -rf build htmlcov doc/_build
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find . -name __pycache__ | xargs rm -fr
@@ -50,8 +54,22 @@ test: build
 coverage: build
 	python -m pytest -v iminuit --cov iminuit --cov-report html --cov-report term-missing --cov-report xml
 
+# TODO: this runs Cython differently than via setup.py ... make it consistent!
 cython:
 	find $(PROJECT) -name "*.pyx" -exec $(CYTHON) --cplus  {} \;
+
+
+# TODO: either of these give warnings or errors ... to be figured out!
+doc: FORCE
+	cd doc && make html
+	# python setup.py build_sphinx
+
+FORCE:
+
+doc-show:
+	open build/sphinx/html/index.html
+	# open doc/_build/html/index.html
+
 
 code-analysis: flake8 pylint
 
@@ -61,8 +79,5 @@ flake8:
 # TODO: once the errors are fixed, remove the -E option and tackle the warnings
 pylint:
 	pylint -E $(PROJECT)/ -d E1103,E0611,E1101 \
-	       --ignore=_astropy_init.py -f colorized \
+	       --ignore="" -f colorized \
 	       --msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})'
-
-doc-show:
-	open build/sphinx/html/index.html

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ cython:
 	find $(PROJECT) -name "*.pyx" -exec $(CYTHON) {} \;
 
 trailing-spaces:
-	find $(PROJECT) examples docs -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
+    # TODO: the perl command doesn't work on my Mac (Christoph).
+	find $(PROJECT) doc -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
 
 code-analysis: flake8 pylint
 

--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,15 @@ cython:
 
 
 # TODO: either of these give warnings or errors ... to be figured out!
-doc: FORCE
+doc: build FORCE
 	cd doc && make html
 	# python setup.py build_sphinx
 
 FORCE:
 
 doc-show:
-	open build/sphinx/html/index.html
-	# open doc/_build/html/index.html
+	# open build/sphinx/html/index.html
+	open doc/_build/html/index.html
 
 
 code-analysis: flake8 pylint

--- a/README.rst
+++ b/README.rst
@@ -16,3 +16,4 @@ MINUIT from Python - Fitting like a boss
 * Documentation: http://iminuit.readthedocs.org/
 * Mailing list: https://groups.google.com/forum/#!forum/iminuit
 * PyPI: https://pypi.python.org/pypi/iminuit
+* License: LGPL

--- a/README.rst
+++ b/README.rst
@@ -16,4 +16,4 @@ MINUIT from Python - Fitting like a boss
 * Documentation: http://iminuit.readthedocs.org/
 * Mailing list: https://groups.google.com/forum/#!forum/iminuit
 * PyPI: https://pypi.python.org/pypi/iminuit
-* License: LGPL
+* License: LGPL (the iminuit source is MIT, but the bundled MINUIT and thus the whole package is LGPL)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,3 +1,5 @@
+.. include:: references.txt
+
 .. _api-doc:
 
 Full API Documentation
@@ -92,8 +94,7 @@ Function Mimum Struct has the following attributes:
 
     * *fval*: FCN minimum value
 
-    * *edm*: `Estimated Distance to Minimum
-      <http://en.wikipedia.org/wiki/Minimum_distance_estimation>`_.
+    * *edm*: `Estimated Distance to Minimum`_
 
     * *nfcn*: Number of function call in last mimizier call
 
@@ -238,7 +239,7 @@ Function Signature Extraction Ordering
     The difference is that it allows you to fake function
     signature by having func_code attribute in the object. This allows you
     to make a generic functor of your custom cost function. This is how
-    `probfit <http://github.com/iminuit/probfit>`_ was written::
+    `probfit`_ was written::
 
         f = lambda x,m,c: m*x+c
         #the beauty here is that all you need to build

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,12 +7,12 @@ MINUIT from Python - Fitting like a boss
 * Documentation: http://iminuit.readthedocs.org/
 * Mailing list: https://groups.google.com/forum/#!forum/iminuit
 * PyPI: https://pypi.python.org/pypi/iminuit
-
+* License: LGPL
 
 What is iminuit?
 ----------------
 
-Interactive IPython-friendly Mimizer based on `SEAL Minuit <http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/>`_.
+Interactive IPython-friendly mimizer based on `SEAL Minuit <http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/>`_.
 
 (It's included in the package, no need to install it separately.)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ MINUIT from Python - Fitting like a boss
 * Documentation: http://iminuit.readthedocs.org/
 * Mailing list: https://groups.google.com/forum/#!forum/iminuit
 * PyPI: https://pypi.python.org/pypi/iminuit
-* License: LGPL
+* License: LGPL (the iminuit source is MIT, but the bundled MINUIT and thus the whole package is LGPL)
 
 What is iminuit?
 ----------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,5 @@
+.. include:: references.txt
+
 iminuit
 =======
 
@@ -12,7 +14,7 @@ MINUIT from Python - Fitting like a boss
 What is iminuit?
 ----------------
 
-Interactive IPython-friendly mimizer based on `SEAL Minuit <http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/>`_.
+Interactive IPython-friendly mimizer based on `SEAL Minuit`_.
 
 (It's included in the package, no need to install it separately.)
 
@@ -37,12 +39,7 @@ In a nutshell
     print(m.values)  # {'x': 2,'y': 3,'z': 4}
     print(m.errors)  # {'x': 1,'y': 1,'z': 1}
 
-If you are interested in fitting a curve or distribution, take a look at
-`probfit <https://github.com/iminuit/probfit>`_. 
-
-.. _lcg-minuit: http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/
-.. _PyMinuit: http://code.google.com/p/pyminuit/
-.. _ipythonnb: http://ipython.org/ipython-doc/dev/notebook/index.html
+If you are interested in fitting a curve or distribution, take a look at `probfit`_.
 
 
 .. toctree::
@@ -61,9 +58,8 @@ All the tutorials are in tutorial directory. You can view them online too:
 - `Quick start <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/iminuit/master/tutorial/tutorial.ipynb>`_
 - `Hard Core Cython tutorial <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/iminuit/master/tutorial/hard-core-tutorial.ipynb>`_.
   If you need to do a huge likelihood fit that needs speed, this is for you.
-  If you don't care, just use `probfit <https://github.com/iminuit/probfit>`_.
+  If you don't care, just use `probfit`_.
   It's a fun read though I think.
-
 
 API
 ---
@@ -77,12 +73,10 @@ Technical Stuff
 Using it as a black box is a bad idea. Here are some fun reads; the order is given
 by the order I think you should read.
 
-* Wikipedia for `Quasi Newton Method <http://en.wikipedia.org/wiki/Quasi-Newton_method>`_ and
-  `DFP formula <http://en.wikipedia.org/wiki/Davidon-Fletcher-Powell_formula>`_.
-  The magic behind migrad.
-* `Variable Metric Method for Minimization <http://www.ii.uib.no/~lennart/drgrad/Davidon1991.pdf>`_ William Davidon 1991
-* `A New Approach to Variable Metric Algorithm. <http://comjnl.oxfordjournals.org/content/13/3/317.full.pdf+html>`_ (R.Fletcher 1970)
-* Original Paper: `MINUIT - A SYSTEM FOR FUNCTION MINIMIZATION AND ANALYSIS OF THE PARAMETER ERRORS AND CORRELATIONS <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.158.9157&rep=rep1&type=pdf>`_ by Fred James and Matts Roos.
+* Wikipedia for `Quasi Newton Method`_ and `DFP formula`_. The magic behind MIGRAD.
+* `Variable Metric Method for Minimization`_ William Davidon 1991
+* `A New Approach to Variable Metric Algorithm`_ (R.Fletcher 1970)
+* Original Paper: `MINUIT - A SYSTEM FOR FUNCTION MINIMIZATION AND ANALYSIS OF THE PARAMETER ERRORS AND CORRELATIONS`_ by Fred James and Matts Roos.
 
 You can help
 ------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -70,9 +70,16 @@ Testing
 
 To run the tests you need to install `pytest <http://pytest.org>`_.
 
-To run the tests, use this command:
+To run the iminuit tests for an installed version of the package:
+
+.. code-block:: bash
+
+    python -m pytest --pyargs iminuit
+
+To run the tests from the source folder (e.g. during pytest development), use these commands:
 
 .. code-block:: bash
 
    $ python setup.py build_ext --inplace
-   $ py.test -v iminuit
+   $ python -m pytest -v iminuit
+   $ python -m pytest -v iminuit --cov iminuit --cov-report html

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -94,10 +94,14 @@ To run the iminuit tests for an installed version of the package:
 
     python -m pytest --pyargs iminuit
 
-To run the tests from the source folder (e.g. during pytest development), use these commands:
+To run the tests from the source folder (e.g. during pytest development), use this command:
 
 .. code-block:: bash
 
-       $ python setup.py build_ext --inplace
-       $ python -m pytest -v iminuit
-       $ python -m pytest -v iminuit --cov iminuit --cov-report html
+    $ make test
+
+To get a coverage report from the tests:
+
+.. code-block:: bash
+
+    $ make coverage

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -68,16 +68,11 @@ They can be installed via
 Testing
 -------
 
-To run the tests:
+To run the tests you need to install `pytest <http://pytest.org>`_.
+
+To run the tests, use this command:
 
 .. code-block:: bash
 
    $ python setup.py build_ext --inplace
-   $ nosetests -V
-
-You will need ``nose``.
-It can be installed via
-
-.. code-block:: bash
-
-   $ pip install nose
+   $ py.test -v iminuit

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,3 +1,5 @@
+.. include:: references.txt
+
 .. _installation:
 
 Installation
@@ -8,7 +10,7 @@ iminuit works with Python 2.7 as well as 3.4 or later.
 Dependencies
 ------------
 
-Like most Python packages, iminuit installation requires `setuptools <https://pypi.python.org/pypi/setuptools>`__
+Like most Python packages, iminuit installation requires `setuptools`_.
 
 The following dependencies are optional:
 
@@ -36,7 +38,7 @@ To install the latest stable version:
 Conda
 -----
 
-Conda packages for iminuit are available via the astropy channel at https://anaconda.org/astropy/iminuit
+Conda packages for iminuit are available via the ``astropy`` channel at https://anaconda.org/astropy/iminuit
 
 .. code-block:: bash
 
@@ -86,7 +88,7 @@ They can be installed via
 Testing
 -------
 
-To run the tests you need to install `pytest <http://pytest.org>`_.
+To run the tests you need to install `pytest`_.
 
 To run the iminuit tests for an installed version of the package:
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,6 +5,23 @@ Installation
 
 iminuit works with Python 2.7 as well as 3.4 or later.
 
+Dependencies
+------------
+
+Like most Python packages, iminuit installation requires `setuptools <https://pypi.python.org/pypi/setuptools>`__
+
+The following dependencies are optional:
+
+* numpy
+* ipython
+* matplotlib
+* pytest, pytest-cov
+* Cython
+
+
+TODO: describe better where which dependency is used.
+
+
 Stable version
 --------------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -98,6 +98,6 @@ To run the tests from the source folder (e.g. during pytest development), use th
 
 .. code-block:: bash
 
-   $ python setup.py build_ext --inplace
-   $ python -m pytest -v iminuit
-   $ python -m pytest -v iminuit --cov iminuit --cov-report html
+       $ python setup.py build_ext --inplace
+       $ python -m pytest -v iminuit
+       $ python -m pytest -v iminuit --cov iminuit --cov-report html

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -17,6 +17,7 @@ The following dependencies are optional:
 * matplotlib
 * pytest, pytest-cov
 * Cython
+* Sphinx, sphinx-rtd
 
 
 TODO: describe better where which dependency is used.

--- a/doc/references.txt
+++ b/doc/references.txt
@@ -1,0 +1,13 @@
+.. _probfit: https://github.com/iminuit/probfit
+.. _SEAL Minuit: http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/
+.. _lcg-minuit: http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/
+.. _PyMinuit: http://code.google.com/p/pyminuit/
+.. _ipythonnb: http://ipython.org/ipython-doc/dev/notebook/index.html
+.. _Quasi Newton Method: http://en.wikipedia.org/wiki/Quasi-Newton_method
+.. _DFP formula: http://en.wikipedia.org/wiki/Davidon-Fletcher-Powell_formula
+.. _Variable Metric Method for Minimization: http://www.ii.uib.no/~lennart/drgrad/Davidon1991.pdf
+.. _A New Approach to Variable Metric Algorithm: http://comjnl.oxfordjournals.org/content/13/3/317.full.pdf+html
+.. _MINUIT - A SYSTEM FOR FUNCTION MINIMIZATION AND ANALYSIS OF THE PARAMETER ERRORS AND CORRELATIONS: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.158.9157&rep=rep1&type=pdf
+.. _setuptools: https://pypi.python.org/pypi/setuptools
+.. _pytest: http://pytest.org
+.. _Estimated Distance to Minimum: http://en.wikipedia.org/wiki/Minimum_distance_estimation

--- a/iminuit/__init__.py
+++ b/iminuit/__init__.py
@@ -21,7 +21,8 @@ __all__ = [
     'describe',
     'Struct',
     'InitialParamWarning',
-    '__version__'
+    '__version__',
+    'test',
 ]
 
 from iminuit._libiminuit import *
@@ -29,14 +30,17 @@ from iminuit.util import describe, Struct
 from iminuit.iminuit_warnings import *
 from iminuit.info import __version__
 
-# Define a test function that runs the `iminuit` tests.
-# This seems to work OK
-# http://docs.scipy.org/doc/numpy/reference/generated/numpy.testing.Tester.test.html
-# try:
-#     from numpy.testing import Tester
-#     test = Tester().test
-# except:
-#     pass
-# An alternative would be to use `nose` directly to avoid the `numpy` depencency
-# `scikit-image` is a nice example we could maybe copy & paste 
-# https://github.com/scikit-image/scikit-image/blob/master/skimage/__init__.py
+
+def test(args=None):
+    """Execute the iminuit tests.
+
+    Requires pytest.
+
+    From the command line:
+
+        python -c 'import iminuit; iminuit.test()
+    """
+    # http://pytest.org/latest/usage.html#calling-pytest-from-python-code
+    import pytest
+    args = '--pyargs iminuit'
+    pytest.main(args)

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -1303,10 +1303,10 @@ cdef class Minuit:
         """
         try:
             __IPYTHON__
-            from .frontends.html import HtmlFrontend
+            from iminuit.frontends.html import HtmlFrontend
             return HtmlFrontend()
         except NameError:
-            from .frontends.console import ConsoleFrontend
+            from iminuit.frontends.console import ConsoleFrontend
             return ConsoleFrontend()
 
     def _check_extra_args(self, parameters, kwd):

--- a/iminuit/_plotting.py
+++ b/iminuit/_plotting.py
@@ -74,7 +74,8 @@ def draw_contour(self, x, y, bins=20, bound=2, args=None, show_sigma=False):
     return vx, vy, vz
 
 
-def mncontour_grid(self, x, y, numpoints=20, nsigma=2, sigma_res=4, bins=100, edges=False):
+def mncontour_grid(self, x, y, numpoints=20, nsigma=2, sigma_res=4,
+                   bins=100, edges=False):
     import numpy as np
     from matplotlib import mlab
     dfcn = []
@@ -85,7 +86,9 @@ def mncontour_grid(self, x, y, numpoints=20, nsigma=2, sigma_res=4, bins=100, ed
         xminos, yminos, pts = self.mncontour(x, y, numpoints=numpoints,
                                              sigma=this_sig)
         if len(pts) == 0:  # pragma: no cover
-            warnings.warn(RuntimeWarning('Fail mncontour for %s, %s, sigma=%f' % (x, y, this_sig)))
+            warnings.warn(RuntimeWarning(
+                'Fail mncontour for %s, %s, sigma=%f' % (x, y, this_sig))
+            )
             continue
 
         xp, yp = zip(*pts)

--- a/iminuit/_plotting.py
+++ b/iminuit/_plotting.py
@@ -124,7 +124,7 @@ def mncontour_grid(self, x, y, numpoints=20, nsigma=2, sigma_res=4, bins=100, ed
         g = mlab.griddata(fx, fy, fz, xgrid, ygrid, interp='linear')
 
     # return grid edges instead of mid point (for pcolor)
-    if edges:  # pragma: no cover 
+    if edges:  # pragma: no cover
         xgrid -= xstep / 2.
         ygrid -= ystep / 2.
         np.resize(xgrid, len(xgrid) + 1)

--- a/iminuit/frontends/html.py
+++ b/iminuit/frontends/html.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import random
 import string
-from IPython.core.display import display_html
 from iminuit.util import Struct
 from iminuit.latex import LatexFactory
 from iminuit.color import Gradient
@@ -66,6 +65,7 @@ class HtmlFrontend:
 
         .. note: Would appreciate if someone would make jquery hover
         description for each item."""
+        from IPython.core.display import display_html
         goaledm = 0.0001 * tolerance * sfmin.up
         style = fmin_style(sfmin)
         header = u"""
@@ -119,6 +119,7 @@ class HtmlFrontend:
 
     @staticmethod
     def print_merror(vname, smerr):
+        from IPython.core.display import display_html
         stat = 'VALID' if smerr.is_valid else 'PROBLEM'
         style = minos_style(smerr)
         to_print = """
@@ -155,6 +156,7 @@ class HtmlFrontend:
 
     def print_param(self, mps, merr=None, float_format='%5.3e',
                     smart_latex=True, latex_map=None):
+        from IPython.core.display import display_html
         """print list of parameters
         Arguments:
 
@@ -233,6 +235,7 @@ class HtmlFrontend:
         return ret
 
     def print_matrix(self, vnames, matrix, latex_map=None):
+        from IPython.core.display import display_html
         latexuid = randid()
         latextable = LatexFactory.build_matrix(vnames, matrix,
                                                latex_map=latex_map)
@@ -276,4 +279,5 @@ class HtmlFrontend:
 
     @staticmethod
     def print_hline():
+        from IPython.core.display import display_html
         display_html('<hr>', raw=True)

--- a/iminuit/tests/cyfunc.pyxbld
+++ b/iminuit/tests/cyfunc.pyxbld
@@ -1,5 +1,5 @@
 def make_ext(modname, pyxfilename):
-    from distutils.extension import Extension
+    from setuptools import Extension
     return Extension(modname,
             sources=[pyxfilename],
             extra_compile_args=['-w']

--- a/iminuit/tests/test_describe.py
+++ b/iminuit/tests/test_describe.py
@@ -2,8 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from iminuit.util import describe
 from math import ldexp
-import pyximport;
-
+import pyximport
 pyximport.install()
 from . import cyfunc
 

--- a/iminuit/tests/test_describe.py
+++ b/iminuit/tests/test_describe.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from nose.tools import assert_equal
 from iminuit.util import describe
 from math import ldexp
 import pyximport;
@@ -15,7 +14,7 @@ def f(x, y):
 
 
 def test_simple():
-    assert_equal(describe(f, True), ['x', 'y'])
+    assert describe(f, True) == ['x', 'y']
 
 
 # test bound method
@@ -26,12 +25,12 @@ class A:
 
 def test_bound():
     a = A()
-    assert_equal(describe(a.f, True), ['x', 'y'])
+    assert describe(a.f, True) == ['x', 'y']
 
 
 # unbound method
 def test_unbound():
-    assert_equal(describe(A.f, True), ['self', 'x', 'y'])
+    assert describe(A.f, True) == ['self', 'x', 'y']
 
 
 # faking func code
@@ -52,7 +51,7 @@ class Func1:
 
 def test_call():
     f1 = Func1()
-    assert_equal(describe(f1, True), ['x', 'y'])
+    assert describe(f1, True) == ['x', 'y']
 
 
 # fake func
@@ -66,18 +65,18 @@ class Func2:
 
 def test_fakefunc():
     f2 = Func2()
-    assert_equal(describe(f2, True), ['x', 'y'])
+    assert describe(f2, True) == ['x', 'y']
 
 
 # builtin (parsing doc)
 def test_builtin():
-    assert_equal(describe(ldexp, True), ['x', 'i'])
+    assert describe(ldexp, True) == ['x', 'i']
 
 
 def test_cython_embedsig():
-    assert_equal(describe(cyfunc.f, True), ['a', 'b'])
+    assert describe(cyfunc.f, True) == ['a', 'b']
 
 
 def test_cython_class_method():
     cc = cyfunc.CyCallable()
-    assert_equal(describe(cc.test, True), ['c', 'd'])
+    assert describe(cc.test, True) == ['c', 'd']

--- a/iminuit/tests/test_frontend.py
+++ b/iminuit/tests/test_frontend.py
@@ -3,12 +3,14 @@ from __future__ import (absolute_import, division, print_function,
 from iminuit import Minuit
 from iminuit.frontends.html import HtmlFrontend
 from iminuit.frontends.console import ConsoleFrontend
+from iminuit.tests.utils import requires_dependency
 
 
 def f1(x, y):
     return (1 - x) ** 2 + 100 * (y - 1) ** 2
 
 
+@requires_dependency('IPython')
 def test_html():
     m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1, frontend=HtmlFrontend())
     m.tol = 1e-4

--- a/iminuit/tests/test_functions.py
+++ b/iminuit/tests/test_functions.py
@@ -2,9 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import random
 from math import sqrt, exp, cos, pi, e
-from nose.tools import assert_almost_equal, assert_less
 from iminuit import Minuit
-from iminuit.tests.utils import assert_array_almost_equal
+from iminuit.tests.utils import assert_allclose
 
 
 def rosenbrock(x, y):
@@ -17,9 +16,9 @@ def test_rosenbrock():
     m = Minuit(rosenbrock, x=0, y=0, pedantic=False, print_level=1)
     m.tol = 1e-4
     m.migrad()
-    assert_less(m.fval, 1e-6)
-    assert_almost_equal(m.values['x'], 1., places=3)
-    assert_almost_equal(m.values['y'], 1., places=3)
+    assert_allclose(m.fval, 0, atol=1e-6)
+    assert_allclose(m.values['x'], 1., atol=1e-3)
+    assert_allclose(m.values['y'], 1., atol=1e-3)
 
 
 def ackleys(x, y):
@@ -37,8 +36,8 @@ def test_ackleys():
     m.tol = 1e-4
     m.migrad()
 
-    assert_less(m.fval, 1e-6)
-    assert_array_almost_equal(m.args, [0, 0], decimal=3)
+    assert_allclose(m.fval, 0, atol=1e-6)
+    assert_allclose(m.args, [0, 0], atol=1e-6)
 
 
 def beale(x, y):
@@ -55,8 +54,8 @@ def test_beale():
                pedantic=False, print_level=0)
     m.tol = 1e-4
     m.migrad()
-    assert_less(m.fval, 1e-6)
-    assert_array_almost_equal(m.args, [3, 0.5], decimal=3)
+    assert_allclose(m.fval, 0, atol=1e-6)
+    assert_allclose(m.args, [3, 0.5], atol=1e-3)
     assert m.fval < 1e-6
 
 
@@ -72,7 +71,7 @@ def test_matyas():
     m.migrad()
 
     assert m.fval < 1e-26
-    assert_array_almost_equal(m.args, [0, 0], decimal=12)
+    assert_allclose(m.args, [0, 0], atol=1e-12)
 
 
 def test_matyas_oneside():
@@ -83,4 +82,4 @@ def test_matyas_oneside():
                pedantic=False, print_level=0)
     m.tol = 1e-4
     m.migrad()
-    assert_array_almost_equal(m.args, [1, 0.923], decimal=3)
+    assert_allclose(m.args, [1, 0.923], atol=1e-3)

--- a/iminuit/tests/test_functions.py
+++ b/iminuit/tests/test_functions.py
@@ -4,7 +4,7 @@ import random
 from math import sqrt, exp, cos, pi, e
 from nose.tools import assert_almost_equal, assert_less
 from iminuit import Minuit
-from iminuit.tests.test_iminuit import assert_array_almost_equal
+from iminuit.tests.utils import assert_array_almost_equal
 
 
 def rosenbrock(x, y):

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -299,7 +299,8 @@ def test_mnprofile():
 
 def test_printfmin_uninitialized():
     # issue 85
-    def f(x): return 2 + 3 * x
+    def f(x):
+        return 2 + 3 * x
 
     fitter = Minuit(f, pedantic=False)
     with pytest.raises(RuntimeError):
@@ -316,8 +317,6 @@ def test_reverse_limit():
         m.migrad()
 
 
-
-# TODO: rewrite using pytest fixture
 class TestMatrix:
     def setup(self):
         self.m = Minuit(func3, print_level=0, pedantic=False)

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -11,20 +11,6 @@ from nose.tools import (raises,
                         )
 from iminuit import Minuit
 
-try:
-    from numpy.testing import assert_array_almost_equal
-except ImportError:
-    def assert_array_almost_equal(actual, expected, decimal=6):
-        """
-        Helper function to test if all elements of a list of lists
-        are almost equal.
-        A replacement for numpy.testing.assert_array_almost_equal,
-        if it is not installed
-        """
-        for row in range(len(actual)):
-            for col in range(len(actual[0])):
-                assert_almost_equal(actual[row][col], expected[row][col], places=decimal)
-
 
 class Func_Code:
     def __init__(self, varname):

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -3,12 +3,14 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 from math import sqrt
 from unittest import TestCase
-from nose.tools import (raises,
-                        assert_equal,
-                        assert_true,
-                        assert_false,
-                        assert_almost_equal,
-                        )
+import pytest
+# from nose.tools import (raises,
+#                         assert_equal,
+#                         assert_true,
+#                         assert_false,
+#                         assert_almost_equal,
+#                         )
+from iminuit.tests.utils import assert_allclose
 from iminuit import Minuit
 
 
@@ -65,9 +67,9 @@ def functesthelper(f):
     m = Minuit(f, print_level=0, pedantic=False)
     m.migrad()
     val = m.values
-    assert_almost_equal(val['x'], 2.)
-    assert_almost_equal(val['y'], 5.)
-    assert_almost_equal(m.fval, 10.)
+    assert_allclose(val['x'], 2.)
+    assert_allclose(val['y'], 5.)
+    assert_allclose(m.fval, 10.)
     assert m.matrix_accurate()
     assert m.migrad_ok()
     return m
@@ -85,9 +87,9 @@ def test_f3():
     functesthelper(func3)
 
 
-@raises(RuntimeError)
 def test_typo():
-    Minuit(func4, printlevel=0)
+    with pytest.raises(RuntimeError):
+        Minuit(func4, printlevel=0)
     # self.assertRaises(RuntimeError,Minuit,func4,printlevel=0)
 
 
@@ -117,99 +119,99 @@ def test_fix_param():
     m.migrad()
     m.minos()
     val = m.values
-    assert_almost_equal(val['x'], 2.)
-    assert_almost_equal(val['y'], 5.)
-    assert_almost_equal(val['z'], 7.)
+    assert_allclose(val['x'], 2.)
+    assert_allclose(val['y'], 5.)
+    assert_allclose(val['z'], 7.)
     err = m.errors  # second derivative
     m.print_all_minos()
     # now fix z = 10
     m = Minuit(func4, print_level=-1, y=10., fix_y=True, pedantic=False)
     m.migrad()
     val = m.values
-    assert_almost_equal(val['x'], 2.)
-    assert_almost_equal(val['y'], 10.)
-    assert_almost_equal(val['z'], 7.)
-    assert_almost_equal(m.fval, 10. + 2.5)
+    assert_allclose(val['x'], 2.)
+    assert_allclose(val['y'], 10.)
+    assert_allclose(val['z'], 7.)
+    assert_allclose(m.fval, 10. + 2.5)
     free_param = m.list_of_vary_param()
     fix_param = m.list_of_fixed_param()
-    assert_true('x' in free_param)
-    assert_false('x' in fix_param)
-    assert_true('y' in fix_param)
-    assert_false('y' in free_param)
-    assert_false('z' in fix_param)
+    assert 'x' in free_param
+    assert 'x' not in fix_param
+    assert 'y' in fix_param
+    assert 'y' not in free_param
+    assert 'z' not in fix_param
 
 
 def test_fitarg_oneside():
     m = Minuit(func4, print_level=-1, y=10., fix_y=True, limit_x=(None, 20.),
                pedantic=False)
     fitarg = m.fitarg
-    assert_almost_equal(fitarg['y'], 10.)
-    assert_true(fitarg['fix_y'])
-    assert_equal(fitarg['limit_x'], (None, 20))
+    assert_allclose(fitarg['y'], 10.)
+    assert fitarg['fix_y']
+    assert fitarg['limit_x'] == (None, 20)
     m.migrad()
 
     fitarg = m.fitarg
 
-    assert_almost_equal(fitarg['y'], 10.)
-    assert_almost_equal(fitarg['x'], 2., places=2)
-    assert_almost_equal(fitarg['z'], 7., places=2)
+    assert_allclose(fitarg['y'], 10.)
+    assert_allclose(fitarg['x'], 2., atol=1e-2)
+    assert_allclose(fitarg['z'], 7., atol=1e-2)
 
-    assert_true('error_y' in fitarg)
-    assert_true('error_x' in fitarg)
-    assert_true('error_z' in fitarg)
+    assert 'error_y' in fitarg
+    assert 'error_x' in fitarg
+    assert 'error_z' in fitarg
 
-    assert_true(fitarg['fix_y'])
-    assert_equal(fitarg['limit_x'], (None, 20))
+    assert fitarg['fix_y']
+    assert fitarg['limit_x'] == (None, 20)
 
 
 def test_fitarg():
     m = Minuit(func4, print_level=-1, y=10., fix_y=True, limit_x=(0, 20.),
                pedantic=False)
     fitarg = m.fitarg
-    assert_almost_equal(fitarg['y'], 10.)
-    assert_true(fitarg['fix_y'])
-    assert_equal(fitarg['limit_x'], (0, 20))
+    assert_allclose(fitarg['y'], 10.)
+    assert fitarg['fix_y'] == True
+    assert fitarg['limit_x'] == (0, 20)
     m.migrad()
 
     fitarg = m.fitarg
 
-    assert_almost_equal(fitarg['y'], 10.)
-    assert_almost_equal(fitarg['x'], 2., places=2)
-    assert_almost_equal(fitarg['z'], 7., places=2)
+    assert_allclose(fitarg['y'], 10.)
+    assert_allclose(fitarg['x'], 2., atol=1e-2)
+    assert_allclose(fitarg['z'], 7., atol=1e-2)
 
-    assert_true('error_y' in fitarg)
-    assert_true('error_x' in fitarg)
-    assert_true('error_z' in fitarg)
+    assert 'error_y' in fitarg
+    assert 'error_x' in fitarg
+    assert 'error_z' in fitarg
 
-    assert_true(fitarg['fix_y'])
-    assert_equal(fitarg['limit_x'], (0, 20))
+    assert fitarg['fix_y'] == True
+    assert fitarg['limit_x'] == (0, 20)
 
 
 def test_minos_all():
     m = Minuit(func3, pedantic=False, print_level=0)
     m.migrad()
     m.minos()
-    assert_almost_equal(m.merrors[('x', -1.0)], -sqrt(5))
-    assert_almost_equal(m.merrors[('x', 1.0)], sqrt(5))
-    assert_almost_equal(m.merrors[('y', 1.0)], 1.)
+    assert_allclose(m.merrors[('x', -1.0)], -sqrt(5))
+    assert_allclose(m.merrors[('x', 1.0)], sqrt(5))
+    assert_allclose(m.merrors[('y', 1.0)], 1.)
 
 
 def test_minos_single():
     m = Minuit(func3, pedantic=False, print_level=0)
     m.migrad()
     m.minos('x')
-    assert_almost_equal(m.merrors[('x', -1.0)], -sqrt(5))
-    assert_almost_equal(m.merrors[('x', 1.0)], sqrt(5))
+    assert_allclose(m.merrors[('x', -1.0)], -sqrt(5))
+    assert_allclose(m.merrors[('x', 1.0)], sqrt(5))
 
 
-@raises(RuntimeWarning)
 def test_minos_single_fixed_raising():
     m = Minuit(func3, pedantic=False, print_level=0, fix_x=True)
     m.migrad()
 
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        ret = m.minos('x')
+        with pytest.raises(RuntimeWarning):
+            m.minos('x')
 
 
 def test_minos_single_fixed_result():
@@ -218,20 +220,20 @@ def test_minos_single_fixed_result():
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         ret = m.minos('x')
-    assert_equal(ret, None)
+    assert ret is None
 
 
-@raises(RuntimeError)
 def test_minos_single_no_migrad():
     m = Minuit(func3, pedantic=False, print_level=0)
-    m.minos('x')
+    with pytest.raises(RuntimeError):
+        m.minos('x')
 
 
-@raises(RuntimeError)
 def test_minos_single_nonsense_variable():
     m = Minuit(func3, pedantic=False, print_level=0)
     m.migrad()
-    m.minos('nonsense')
+    with pytest.raises(RuntimeError):
+        m.minos('nonsense')
 
 
 def test_fixing_long_variable_name():
@@ -243,11 +245,11 @@ def test_fixing_long_variable_name():
 
 def test_initial_value():
     m = Minuit(func3, pedantic=False, x=1., y=2., error_x=3., print_level=0)
-    assert_almost_equal(m.args[0], 1.)
-    assert_almost_equal(m.args[1], 2.)
-    assert_almost_equal(m.values['x'], 1.)
-    assert_almost_equal(m.values['y'], 2.)
-    assert_almost_equal(m.errors['x'], 3.)
+    assert_allclose(m.args[0], 1.)
+    assert_allclose(m.args[1], 2.)
+    assert_allclose(m.values['x'], 1.)
+    assert_allclose(m.values['y'], 2.)
+    assert_allclose(m.errors['x'], 3.)
 
 
 def test_mncontour():
@@ -256,12 +258,12 @@ def test_mncontour():
     xminos, yminos, ctr = m.mncontour('x', 'y', numpoints=30)
     xminos_t = m.minos('x')['x']
     yminos_t = m.minos('y')['y']
-    assert_almost_equal(xminos.upper, xminos_t.upper)
-    assert_almost_equal(xminos.lower, xminos_t.lower)
-    assert_almost_equal(yminos.upper, yminos_t.upper)
-    assert_almost_equal(yminos.lower, yminos_t.lower)
-    assert_equal(len(ctr), 30)
-    assert_equal(len(ctr[0]), 2)
+    assert_allclose(xminos.upper, xminos_t.upper)
+    assert_allclose(xminos.lower, xminos_t.lower)
+    assert_allclose(yminos.upper, yminos_t.upper)
+    assert_allclose(yminos.lower, yminos_t.lower)
+    assert len(ctr) == 30
+    assert len(ctr[0]) == 2
 
 
 def test_mncontour_sigma():
@@ -270,12 +272,12 @@ def test_mncontour_sigma():
     xminos, yminos, ctr = m.mncontour('x', 'y', numpoints=30, sigma=2.0)
     xminos_t = m.minos('x', sigma=2.0)['x']
     yminos_t = m.minos('y', sigma=2.0)['y']
-    assert_almost_equal(xminos.upper, xminos_t.upper)
-    assert_almost_equal(xminos.lower, xminos_t.lower)
-    assert_almost_equal(yminos.upper, yminos_t.upper)
-    assert_almost_equal(yminos.lower, yminos_t.lower)
-    assert_equal(len(ctr), 30)
-    assert_equal(len(ctr[0]), 2)
+    assert_allclose(xminos.upper, xminos_t.upper)
+    assert_allclose(xminos.lower, xminos_t.lower)
+    assert_allclose(yminos.upper, yminos_t.upper)
+    assert_allclose(yminos.lower, yminos_t.lower)
+    assert len(ctr) == 30
+    assert len(ctr[0]) == 2
 
 
 def test_contour():
@@ -299,23 +301,23 @@ def test_mnprofile():
     m.mnprofile('y')
 
 
-@raises(RuntimeError)
 def test_printfmin_uninitialized():
     # issue 85
     def f(x): return 2 + 3 * x
 
     fitter = Minuit(f, pedantic=False)
-    fitter.print_fmin()
+    with pytest.raises(RuntimeError):
+        fitter.print_fmin()
 
 
-@raises(ValueError)
 def test_reverse_limit():
     # issue 94
     def f(x, y, z):
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
     m = Minuit(f, limit_x=(3., 2.), pedantic=False)
-    m.migrad()
+    with pytest.raises(ValueError):
+        m.migrad()
 
 
 class TestMatrix(TestCase):
@@ -326,25 +328,25 @@ class TestMatrix(TestCase):
     def test_matrix(self):
         actual = self.m.np_matrix()
         expected = [[5., 0.], [0., 1.]]
-        assert_array_almost_equal(actual, expected)
+        assert_allclose(actual, expected)
 
     def test_np_matrix(self):
         import numpy as np
         actual = self.m.np_matrix()
         expected = [[5., 0.], [0., 1.]]
-        assert_array_almost_equal(actual, expected)
+        assert_allclose(actual, expected)
         assert isinstance(actual, np.ndarray)
 
     def test_matrix_correlation(self):
         actual = self.m.matrix(correlation=True)
         expected = [[1., 0.], [0., 1.]]
-        assert_array_almost_equal(actual, expected)
+        assert_allclose(actual, expected)
 
     def test_np_matrix_correlation(self):
         import numpy as np
         actual = self.m.np_matrix(correlation=True)
         expected = [[1., 0.], [0., 1.]]
-        assert_array_almost_equal(actual, expected)
+        assert_allclose(actual, expected)
         assert isinstance(actual, np.ndarray)
 
 
@@ -357,7 +359,7 @@ def test_chi2_fit():
               round(100 * m.values['m'])]
     expected = [round(10 * 64.375993), round(100 * 4.267970),
                 round(100 * 9.839172)]
-    assert_array_almost_equal(output, expected)
+    assert_allclose(output, expected)
 
 
 def test_oneside():
@@ -368,11 +370,11 @@ def test_oneside():
     m_nolimit.tol = 1e-4
     m_limit.migrad()
     m_nolimit.migrad()
-    assert_array_almost_equal(list(m_limit.values.values()),
-                              list(m_nolimit.values.values()), decimal=4)
+    assert_allclose(list(m_limit.values.values()),
+                    list(m_nolimit.values.values()), atol=1e-4)
 
 
 def test_oneside_outside():
     m = Minuit(func3, limit_x=(None, 1), pedantic=False, print_level=0)
     m.migrad()
-    assert_almost_equal(m.values['x'], 1)
+    assert_allclose(m.values['x'], 1)

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -2,14 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import warnings
 from math import sqrt
-from unittest import TestCase
 import pytest
-# from nose.tools import (raises,
-#                         assert_equal,
-#                         assert_true,
-#                         assert_false,
-#                         assert_almost_equal,
-#                         )
 from iminuit.tests.utils import assert_allclose
 from iminuit import Minuit
 
@@ -90,7 +83,7 @@ def test_f3():
 def test_typo():
     with pytest.raises(RuntimeError):
         Minuit(func4, printlevel=0)
-    # self.assertRaises(RuntimeError,Minuit,func4,printlevel=0)
+        # self.assertRaises(RuntimeError,Minuit,func4,printlevel=0)
 
 
 def test_non_invertible():
@@ -110,7 +103,7 @@ def test_non_invertible():
     try:
         m.matrix()
         raise RuntimeError('Matrix did not raise an error')  # shouldn't reach here
-    except RuntimeError as e:
+    except RuntimeError:
         pass
 
 
@@ -119,18 +112,21 @@ def test_fix_param():
     m.migrad()
     m.minos()
     val = m.values
-    assert_allclose(val['x'], 2.)
-    assert_allclose(val['y'], 5.)
-    assert_allclose(val['z'], 7.)
+    assert_allclose(val['x'], 2)
+    assert_allclose(val['y'], 5)
+    assert_allclose(val['z'], 7)
     err = m.errors  # second derivative
+    assert_allclose(err['x'], 2.236067977354171)
+    assert_allclose(err['y'], 3.1622776602288)
+    assert_allclose(err['z'], 2)
     m.print_all_minos()
     # now fix z = 10
     m = Minuit(func4, print_level=-1, y=10., fix_y=True, pedantic=False)
     m.migrad()
     val = m.values
-    assert_allclose(val['x'], 2.)
-    assert_allclose(val['y'], 10.)
-    assert_allclose(val['z'], 7.)
+    assert_allclose(val['x'], 2)
+    assert_allclose(val['y'], 10)
+    assert_allclose(val['z'], 7)
     assert_allclose(m.fval, 10. + 2.5)
     free_param = m.list_of_vary_param()
     fix_param = m.list_of_fixed_param()
@@ -169,7 +165,7 @@ def test_fitarg():
                pedantic=False)
     fitarg = m.fitarg
     assert_allclose(fitarg['y'], 10.)
-    assert fitarg['fix_y'] == True
+    assert fitarg['fix_y'] is True
     assert fitarg['limit_x'] == (0, 20)
     m.migrad()
 
@@ -183,7 +179,7 @@ def test_fitarg():
     assert 'error_x' in fitarg
     assert 'error_z' in fitarg
 
-    assert fitarg['fix_y'] == True
+    assert fitarg['fix_y'] is True
     assert fitarg['limit_x'] == (0, 20)
 
 
@@ -320,8 +316,10 @@ def test_reverse_limit():
         m.migrad()
 
 
-class TestMatrix(TestCase):
-    def setUp(self):
+
+# TODO: rewrite using pytest fixture
+class TestMatrix:
+    def setup(self):
         self.m = Minuit(func3, print_level=0, pedantic=False)
         self.m.migrad()
 

--- a/iminuit/tests/test_latex.py
+++ b/iminuit/tests/test_latex.py
@@ -1,65 +1,41 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from nose.tools import assert_equal
 from iminuit.latex import LatexTable
 
 
 def test_table():
     ltt = LatexTable(data=[['alpha', 10.123], ['alpha_s', 30]])
-    assert_equal(str(ltt),
-                 '\\begin{tabular}{|c|c|}\n\\hline\n$\\alpha$ &     10.123\\\\\n\\hline\n$\\alpha_{s}$ & 30\\\\\n\\hline\n\\end{tabular}'
-                 )
+    expected = '\\begin{tabular}{|c|c|}\n\\hline\n$\\alpha$ &     10.123\\\\\n\\hline\n$\\alpha_{s}$ & 30\\\\\n\\hline\n\\end{tabular}'
+    assert str(ltt) == expected
 
 
 def test_table_color():
     ltt = LatexTable(data=[['alpha', 10.123], ['alpha_s', 30]])
     ltt.set_cell_color(0, 0, (111, 123, 95))
-    assert_equal(str(ltt),
-                 '%\\usepackage[table]{xcolor} % include this for color\n%\\usepackage{rotating} % include this for rotate header\n%\\documentclass[xcolor=table]{beamer} % for beamer\n\\begin{tabular}{|c|c|}\n\\hline\n\\cellcolor[RGB]{111,123,95} $\\alpha$ &     10.123\\\\\n\\hline\n$\\alpha_{s}$ & 30\\\\\n\\hline\n\\end{tabular}'
-                 )
+    expected = '%\\usepackage[table]{xcolor} % include this for color\n%\\usepackage{rotating} % include this for rotate header\n%\\documentclass[xcolor=table]{beamer} % for beamer\n\\begin{tabular}{|c|c|}\n\\hline\n\\cellcolor[RGB]{111,123,95} $\\alpha$ &     10.123\\\\\n\\hline\n$\\alpha_{s}$ & 30\\\\\n\\hline\n\\end{tabular}'
+    assert str(ltt) == expected
 
 
 def test_latexmap():
     ltt = LatexTable(data=[['alpha', 10.123, 20], ['alpha_s', 30, 40]],
                      latex_map={'alpha': 'beta'})
-    assert_equal(
-        ltt._format('alpha'),
-        'beta'
-    )
+    assert ltt._format('alpha') == 'beta'
 
 
 def test_smartlatex():
     ltt = LatexTable(data=[['alpha', 10.123, 20], ['alpha_s', 30, 40]])
-    assert_equal(
-        ltt._convert_smart_latex('alpha'),
-        r'$\alpha$'
-    )
-    assert_equal(
-        ltt._convert_smart_latex('alpha_beta'),
-        r'$\alpha_{\beta}$'
-    )
-    assert_equal(
-        ltt._convert_smart_latex('a_b'),
-        r'$a_{b}$'
-    )
-    assert_equal(
-        ltt._convert_smart_latex('a_b_c'),
-        r'a $b_{c}$'
-    )
-    assert_equal(
-        ltt._convert_smart_latex('a'),
-        r'a'
-    )
-    assert_equal(
-        ltt._convert_smart_latex('a_alpha_beta'),
-        r'a $\alpha_{\beta}$'
-    )
+    assert ltt._convert_smart_latex('alpha') == r'$\alpha$'
+    assert ltt._convert_smart_latex('alpha_beta') == r'$\alpha_{\beta}$'
+    assert ltt._convert_smart_latex('a_b') == r'$a_{b}$'
+    assert ltt._convert_smart_latex('a_b_c') == r'a $b_{c}$'
+    assert ltt._convert_smart_latex('a') == r'a'
+    assert ltt._convert_smart_latex('a_alpha_beta') == r'a $\alpha_{\beta}$'
 
 
 def test_format():
     ltt = LatexTable(data=[['alpha', 10.123, 20], ['alpha_s', 30, 40]],
                      smart_latex=False)
-    assert_equal(ltt._format('a_b'), r'a\_b')
+    assert ltt._format('a_b') == r'a\_b'
     ltt2 = LatexTable(data=[['alpha', 10.123, 20], ['alpha_s', 30, 40]],
                       smart_latex=False, escape_under_score=False)
-    assert_equal(ltt2._format('a_b'), r'a_b')
+    assert ltt2._format('a_b') == r'a_b'

--- a/iminuit/tests/test_plot.py
+++ b/iminuit/tests/test_plot.py
@@ -1,58 +1,50 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import pytest
 from iminuit import Minuit
-from nose.tools import (assert_almost_equal,
-                        assert_less
-                        )
+from iminuit.tests.utils import assert_allclose, requires_dependency
 
-import matplotlib as mpl
-
-mpl.use('Agg')
+try:
+    import matplotlib as mpl
+    mpl.use('Agg')
+except ImportError:
+    pass
 
 
 def f1(x, y):
     return (1 - x) ** 2 + 100 * (y - 1) ** 2
 
 
-def test_mnprofile():
+@pytest.fixture
+def m():
     m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1)
     m.tol = 1e-4
     m.migrad()
-    assert_less(m.fval, 1e-6)
-    assert_almost_equal(m.values['x'], 1., places=3)
-    assert_almost_equal(m.values['y'], 1., places=3)
+    assert_allclose(m.fval, 0, atol=1e-6)
+    assert_allclose(m.values['x'], 1, atol=1e-3)
+    assert_allclose(m.values['y'], 1, atol=1e-3)
+    return m
+
+
+@requires_dependency('matplotlib')
+def test_mnprofile(m):
     m.minos('x')
     m.draw_mnprofile('x')
 
 
-def test_mncontour():
-    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1)
-    m.tol = 1e-4
-    m.migrad()
-    assert_less(m.fval, 1e-6)
-    assert_almost_equal(m.values['x'], 1., places=3)
-    assert_almost_equal(m.values['y'], 1., places=3)
+@requires_dependency('matplotlib')
+def test_mncontour(m):
     m.minos()
     m.draw_mncontour('x', 'y')
 
 
-def test_drawcontour():
-    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1)
-    m.tol = 1e-4
-    m.migrad()
-    assert_less(m.fval, 1e-6)
-    assert_almost_equal(m.values['x'], 1., places=3)
-    assert_almost_equal(m.values['y'], 1., places=3)
+@requires_dependency('matplotlib')
+def test_drawcontour(m):
     m.minos()
     m.draw_contour('x', 'y')
 
 
-def test_drawcontour_show_sigma():
-    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1)
-    m.tol = 1e-4
-    m.migrad()
-    assert_less(m.fval, 1e-6)
-    assert_almost_equal(m.values['x'], 1., places=3)
-    assert_almost_equal(m.values['y'], 1., places=3)
+@requires_dependency('matplotlib')
+def test_drawcontour_show_sigma(m):
     m.minos()
     m.draw_contour('x', 'y', show_sigma=True)

--- a/iminuit/tests/test_util.py
+++ b/iminuit/tests/test_util.py
@@ -34,10 +34,10 @@ def test_fitarg_rename_strprefix():
 
 
 def test_true_param():
-    assert true_param('N') == True
-    assert true_param('limit_N') == False
-    assert true_param('error_N') == False
-    assert true_param('fix_N') == False
+    assert true_param('N') is True
+    assert true_param('limit_N') is False
+    assert true_param('error_N') is False
+    assert true_param('fix_N') is False
 
 
 def test_param_name():
@@ -95,10 +95,14 @@ def test_remove_var():
     d.update(dn)
 
     ret = remove_var(d, ['k', 'm'])
-    for k in dk: assert k not in ret
-    for k in dl: assert k in ret
-    for k in dm: assert k not in ret
-    for k in dn: assert k in ret
+    for k in dk:
+        assert k not in ret
+    for k in dl:
+        assert k in ret
+    for k in dm:
+        assert k not in ret
+    for k in dn:
+        assert k in ret
 
 
 def test_arguments_from_docstring():

--- a/iminuit/tests/test_util.py
+++ b/iminuit/tests/test_util.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from nose.tools import assert_false, assert_true, assert_equal
 from iminuit.util import (fitarg_rename,
                           true_param,
                           param_name,
@@ -17,71 +16,71 @@ def test_fitarg_rename():
     fitarg = {'x': 1, 'limit_x': (2, 3), 'fix_x': True, 'error_x': 10}
     ren = lambda x: 'z_' + x
     newfa = fitarg_rename(fitarg, ren)
-    assert_true('z_x' in newfa)
-    assert_true('limit_z_x' in newfa)
-    assert_true('error_z_x' in newfa)
-    assert_true('fix_z_x' in newfa)
-    assert_equal(len(newfa), 4)
+    assert 'z_x' in newfa
+    assert 'limit_z_x' in newfa
+    assert 'error_z_x' in newfa
+    assert 'fix_z_x' in newfa
+    assert len(newfa) == 4
 
 
 def test_fitarg_rename_strprefix():
     fitarg = {'x': 1, 'limit_x': (2, 3), 'fix_x': True, 'error_x': 10}
     newfa = fitarg_rename(fitarg, 'z')
-    assert_true('z_x' in newfa)
-    assert_true('limit_z_x' in newfa)
-    assert_true('error_z_x' in newfa)
-    assert_true('fix_z_x' in newfa)
-    assert_equal(len(newfa), 4)
+    assert 'z_x' in newfa
+    assert 'limit_z_x' in newfa
+    assert 'error_z_x' in newfa
+    assert 'fix_z_x' in newfa
+    assert len(newfa) == 4
 
 
 def test_true_param():
-    assert_true(true_param('N'))
-    assert_false(true_param('limit_N'))
-    assert_false(true_param('error_N'))
-    assert_false(true_param('fix_N'))
+    assert true_param('N') == True
+    assert true_param('limit_N') == False
+    assert true_param('error_N') == False
+    assert true_param('fix_N') == False
 
 
 def test_param_name():
-    assert_equal(param_name('N'), 'N')
-    assert_equal(param_name('limit_N'), 'N')
-    assert_equal(param_name('error_N'), 'N')
-    assert_equal(param_name('fix_N'), 'N')
+    assert param_name('N') == 'N'
+    assert param_name('limit_N') == 'N'
+    assert param_name('error_N') == 'N'
+    assert param_name('fix_N') == 'N'
 
 
 def test_extract_iv():
     d = dict(k=1., limit_k=1., error_k=1., fix_k=1.)
     ret = extract_iv(d)
-    assert_true('k' in ret)
-    assert_false('limit_k' in ret)
-    assert_false('error_k' in ret)
-    assert_false('fix_k' in ret)
+    assert 'k' in ret
+    assert 'limit_k' not in ret
+    assert 'error_k' not in ret
+    assert 'fix_k' not in ret
 
 
 def test_extract_limit():
     d = dict(k=1., limit_k=1., error_k=1., fix_k=1.)
     ret = extract_limit(d)
-    assert_false('k' in ret)
-    assert_true('limit_k' in ret)
-    assert_false('error_k' in ret)
-    assert_false('fix_k' in ret)
+    assert 'k' not in ret
+    assert 'limit_k' in ret
+    assert 'error_k' not in ret
+    assert 'fix_k' not in ret
 
 
 def test_extract_error():
     d = dict(k=1., limit_k=1., error_k=1., fix_k=1.)
     ret = extract_error(d)
-    assert_false('k' in ret)
-    assert_false('limit_k' in ret)
-    assert_true('error_k' in ret)
-    assert_false('fix_k' in ret)
+    assert 'k' not in ret
+    assert 'limit_k' not in ret
+    assert 'error_k' in ret
+    assert 'fix_k' not in ret
 
 
 def test_extract_fix():
     d = dict(k=1., limit_k=1., error_k=1., fix_k=1.)
     ret = extract_fix(d)
-    assert_false('k' in ret)
-    assert_false('limit_k' in ret)
-    assert_false('error_k' in ret)
-    assert_true('fix_k' in ret)
+    assert 'k' not in ret
+    assert 'limit_k' not in ret
+    assert 'error_k' not in ret
+    assert 'fix_k' in ret
 
 
 def test_remove_var():
@@ -96,17 +95,17 @@ def test_remove_var():
     d.update(dn)
 
     ret = remove_var(d, ['k', 'm'])
-    for k in dk: assert_false(k in ret)
-    for k in dl: assert_true(k in ret)
-    for k in dm: assert_false(k in ret)
-    for k in dn: assert_true(k in ret)
+    for k in dk: assert k not in ret
+    for k in dl: assert k in ret
+    for k in dm: assert k not in ret
+    for k in dn: assert k in ret
 
 
 def test_arguments_from_docstring():
     s = 'f(x, y, z)'
     a = arguments_from_docstring(s)
-    assert_equal(a, ['x', 'y', 'z'])
+    assert a == ['x', 'y', 'z']
     # this is a hard one
     s = 'Minuit.migrad( int ncall_me =10000, [resume=True, int nsplit=1])'
     a = arguments_from_docstring(s)
-    assert_equal(a, ['ncall_me', 'resume', 'nsplit'])
+    assert a == ['ncall_me', 'resume', 'nsplit']

--- a/iminuit/tests/utils.py
+++ b/iminuit/tests/utils.py
@@ -1,7 +1,10 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-__all__ = ['requires_dependency']
+__all__ = [
+    'requires_dependency',
+    'assert_allclose',
+]
 
 
 def requires_dependency(name):
@@ -33,3 +36,9 @@ def requires_dependency(name):
     reason = 'Missing dependency: {}'.format(name)
     import pytest
     return pytest.mark.skipif(skip_it, reason=reason)
+
+try:
+    from numpy.testing import assert_allclose
+except ImportError:
+    print('ERROR: Running the iminuit tests requires Numpy (for float comparisons)!')
+    raise

--- a/iminuit/tests/utils.py
+++ b/iminuit/tests/utils.py
@@ -1,0 +1,35 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+__all__ = ['requires_dependency']
+
+
+def requires_dependency(name):
+    """Decorator to declare required dependencies for tests.
+
+    Parameters
+    ----------
+    name : str
+        Package name, e.g. 'numpy' or 'ipython'
+
+    Examples
+    --------
+
+    ::
+
+        from iminuit.tests.utils import requires_dependency
+
+        @requires_dependency('numpy')
+        def test_using_numpy():
+            import numpy
+            ...
+    """
+    try:
+        __import__(name)
+        skip_it = False
+    except ImportError:
+        skip_it = True
+
+    reason = 'Missing dependency: {}'.format(name)
+    import pytest
+    return pytest.mark.skipif(skip_it, reason=reason)

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -159,7 +159,7 @@ def better_arg_spec(f, verbose=False):
     #         print(e)
     #         print("inspect.getargspec(f)[0] fails")
 
-    # try: 
+    # try:
     #     return list(inspect.getargspec(f)[0])
     # except Exception as e:
     #     if verbose:

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     extras_require={
         'all': ['numpy', 'ipython', 'matplotlib'],
     },
-    tests_require=['pytest', 'pytest-cov'],
+    tests_require=['pytest', 'pytest-cov', 'numpy'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     ext_modules=extensions,
     install_requires=['setuptools'],
     extras_require={
-        'all': ['numpy', 'ipython'],
+        'all': ['numpy', 'ipython', 'matplotlib'],
     },
     tests_require=['pytest', 'pytest-cov'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
+import sys
 from os.path import dirname, join
 from glob import glob
-from distutils.core import setup, Command
-import os
+from setuptools import setup, Extension
+from setuptools.command.test import test as TestCommand
 
 
-class CoverageCommand(Command):
-    description = "Produce coverage report"
-    user_options = []
+# http://pytest.org/latest/goodpractices.html#manual-integration
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
     def initialize_options(self):
-        self.cwd = None
+        TestCommand.initialize_options(self)
+        # self.pytest_args = '--pyargs iminuit'
+        # self.pytest_args = ['--strict', '--verbose', '--tb=long', 'tests']
+        self.pytest_args = []
+        self.test_suite = True
 
-    def finalize_options(self):
-        self.cwd = os.getcwd()
-
-    def run(self):
-        assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
-        os.system('nosetests --with-coverage --cover-erase --cover-package=iminuit --cover-html iminuit')
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
 
 
 # Static linking
@@ -66,11 +66,13 @@ def get_version():
 
 __version__ = get_version()
 
+long_description = ''.join(open('README.rst').readlines()[4:])
+
 setup(
     name='iminuit',
     version=__version__,
     description='MINUIT from Python - Fitting like a boss',
-    long_description=''.join(open('README.rst').readlines()[4:]),
+    long_description=long_description,
     author='Piti Ongmongkolkul',
     author_email='piti118@gmail.com',
     url='https://github.com/iminuit/iminuit',
@@ -79,7 +81,11 @@ setup(
     package_dir={'iminuit': 'iminuit'},
     packages=['iminuit', 'iminuit.frontends', 'iminuit.tests'],
     ext_modules=extensions,
-    test_suite='nose.collector',
+    install_requires=['setuptools'],
+    extras_require={
+        'all': ['numpy', 'ipython'],
+    },
+    tests_require=['pytest', 'pytest-cov'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
@@ -98,6 +104,7 @@ setup(
         'License :: OSI Approved :: MIT License'
     ],
     cmdclass={
-        'coverage': CoverageCommand
+        'test': PyTest,
+        # 'coverage': CoverageCommand,
     }
 )


### PR DESCRIPTION
Changes in this pull request:

- [x] always use setuptools (don't fall back on distutils). This has been the recommended way for Python packaging for a few years now, see [here](https://python-packaging.readthedocs.org/en/latest/index.html).
- [x] use [pytest](http://pytest.org/) instead of unittest and nose. unittest is cumbersome. nose is not maintained for a while now, nose2 doesn't get much traction, pytest is by far the most popular Python test package by now and it's the one I have most experience with.
- [x] use `numpy.testing.assert_allclose` for float comparisons everywhere (aliased to `iminuit.tests.utils.assert_allclose`). Running the tests requires numpy at the moment.
- [x] add Makefile to not have to remember how to run tests / docs / ...
- [x] mention license in README and docs
- [x] Factor URL links in the Sphinx docs out into separate `references.txt`

