### PR TITLE
Add support for supplying the gradient function to minuit

### DIFF
--- a/iminuit/Minuit2.pxi
+++ b/iminuit/Minuit2.pxi
@@ -14,6 +14,14 @@ cdef extern from "Minuit2/FCNBase.h":
         double call "operator()"(vector[double] x) except+
         double ErrorDef()
 
+cdef extern from "Minuit2/FCNGradientBase.h":
+    cdef cppclass FCNGradientBase:
+        FCNGradientBase(object fcn, double up_parm, vector[string] pname, bint thrownan)
+        double call "operator()"(vector[double] x) except +  #raise_py_err
+        double Up()
+        vector[double] Gradient(vector[double] x) except +  #raise_py_err
+        bint CheckGradient()
+
 cdef extern from "Minuit2/MnApplication.h":
     cdef cppclass MnApplication:
         FunctionMinimum call "operator()"(int, double) except+
@@ -89,6 +97,7 @@ cdef extern from "Minuit2/MnStrategy.h":
 cdef extern from "Minuit2/MnMigrad.h":
     cdef cppclass MnMigrad(MnApplication):
         MnMigrad(FCNBase fcn, MnUserParameterState par, MnStrategy str) except+
+        MnMigrad(FCNGradientBase fcn, MnUserParameterState par, MnStrategy str) except+
         FunctionMinimum call "operator()"(int, double) except+
         void SetPrecision(double)
 
@@ -96,10 +105,12 @@ cdef extern from "Minuit2/MnHesse.h":
     cdef cppclass MnHesse:
         MnHesse(unsigned int stra)
         MnUserParameterState call "operator()"(FCNBase, MnUserParameterState, unsigned int maxcalls=0) except+
+        MnUserParameterState call "operator()"(FCNGradientBase, MnUserParameterState, unsigned int maxcalls=0) except+
 
 cdef extern from "Minuit2/MnMinos.h":
     cdef cppclass MnMinos:
         MnMinos(FCNBase fcn, FunctionMinimum min, unsigned int stra)
+        MnMinos(FCNGradientBase fcn, FunctionMinimum min, unsigned int stra)
         MinosError Minos(unsigned int par, unsigned int maxcalls) except +
 
 cdef extern from "Minuit2/MinosError.h":
@@ -148,6 +159,7 @@ cdef extern from "Minuit2/VariableMetricBuilder.h":
 cdef extern from "Minuit2/MnContours.h":
     cdef cppclass MnContours:
         MnContours(FCNBase fcn, FunctionMinimum fm, unsigned int stra)
+        MnContours(FCNGradientBase fcn, FunctionMinimum fm, unsigned int stra)
         ContoursError Contour(unsigned int, unsigned int, unsigned int npoints)
 
 cdef extern from "Minuit2/ContoursError.h":

--- a/iminuit/PythonFCNBase.h
+++ b/iminuit/PythonFCNBase.h
@@ -1,0 +1,16 @@
+#ifndef PYTHONFCNBASE
+#define PYTHONFCNBASE
+
+class PythonFCNBase {
+    public:virtual ~PythonFCNBase() {}
+    virtual double operator()(const std::vector<double>& x) const = 0;
+    virtual double ErrorDef() const {return Up();}
+    virtual double Up() const = 0;
+    virtual void SetErrorDef(double ) {};
+
+    int getNumCall() const {return 0;};
+    void set_up(double up) {};
+    void resetNumCall() {};
+};
+
+#endif  // PYTHONFCNBASE

--- a/iminuit/PythonGradientFCN.h
+++ b/iminuit/PythonGradientFCN.h
@@ -8,87 +8,49 @@ using namespace std;
 #include <cstdio>
 #include <cmath>
 #include <Python.h>
-#include "Minuit2/FCNBase.h"
+#include "Minuit2/FCNGradientBase.h"
 #include "Minuit2/MnApplication.h"
 #include "PythonFCNBase.h"
 
 using namespace ROOT::Minuit2;
 
-//missing string printf
-//this is safe and convenient but not exactly efficient
-inline std::string format(const char* fmt, ...){
-    int size = 512;
-    char* buffer = 0;
-    buffer = new char[size];
-    va_list vl;
-    va_start(vl,fmt);
-    int nsize = vsnprintf(buffer,size,fmt,vl);
-    if(size<=nsize){//fail delete buffer and try again
-        delete buffer; buffer = 0;
-        buffer = new char[nsize+1];//+1 for /0
-        nsize = vsnprintf(buffer,size,fmt,vl);
-    }
-    std::string ret(buffer);
-    va_end(vl);
-    delete buffer;
-    return ret;
-}
-
-int raise_py_err(){
-    try{
-        if(PyErr_Occurred()){
-            return NULL;
-        }else{
-            throw;
-        }
-    }catch(const std::exception& exn){
-        PyErr_SetString(PyExc_RuntimeError, exn.what());
-        return NULL;
-    }
-    return NULL;
-}
-
-//mnapplication() returns stack allocated functionminimum but
-//cython doesn't like it since it has no default constructor
-//wrap this in a throw since it calls python function it will throw
-//caller is responsible to clean up the object
-FunctionMinimum* call_mnapplication_wrapper(MnApplication& app,unsigned int i, double tol){
-    FunctionMinimum* ret = new FunctionMinimum(app(i,tol));
-    return ret;
-}
-
-class PythonFCN:public FCNBase, public PythonFCNBase{
+class PythonGradientFCN:public FCNGradientBase, public PythonFCNBase{
 public:
     PyObject* fcn;
+    PyObject* gradfcn;
     double up_parm;
     vector<string> pname;
     bool thrownan;
     mutable unsigned int ncall;
 
-    PythonFCN():fcn(), up_parm(), pname(),
+    PythonGradientFCN():fcn(), gradfcn(), up_parm(), pname(),
     thrownan(), ncall(0)
     {}//for cython stack allocate but don't call this
 
-    PythonFCN(PyObject* fcn,
+    PythonGradientFCN(PyObject* fcn,
+        PyObject* gradfcn,
         double up_parm,
         const vector<string>& pname,
         bool thrownan = false)
-        :fcn(fcn),up_parm(up_parm),pname(pname),
+        :fcn(fcn),gradfcn(gradfcn),up_parm(up_parm),pname(pname),
         thrownan(thrownan), ncall(0)
     {
         Py_INCREF(fcn);
+        Py_INCREF(gradfcn);
     }
 
-    PythonFCN(const PythonFCN& pfcn)
-        :fcn(pfcn.fcn),up_parm(pfcn.up_parm),pname(pfcn.pname),
+    PythonGradientFCN(const PythonGradientFCN& pfcn)
+        :fcn(pfcn.fcn),gradfcn(pfcn.gradfcn),up_parm(pfcn.up_parm),pname(pfcn.pname),
         thrownan(pfcn.thrownan), ncall(pfcn.ncall)
     {
         Py_INCREF(fcn);
+        Py_INCREF(gradfcn);
     }
 
-    virtual ~PythonFCN()
+    virtual ~PythonGradientFCN()
     {
         Py_DECREF(fcn);
+        Py_DECREF(gradfcn);
     }
 
     virtual double operator()(const std::vector<double>& x) const{
@@ -126,6 +88,65 @@ public:
         return ret;
     }
 
+    virtual std::vector<double> Gradient(const std::vector<double>& x) const{
+        //pack in tuple
+        PyObject* tuple = vector2tuple(x);
+        //call
+        PyObject* result = PyObject_Call(gradfcn,tuple,NULL);
+        //check result exception etc
+        PyObject* exc = NULL;
+        if((exc = PyErr_Occurred())){
+            string msg = "Exception Occured \n"+graderrormsg(x);
+            warn_preserve_error(msg.c_str());
+            throw runtime_error(msg);
+        }
+        // Convert the iterable to a vector
+        PyObject *iterator = PyObject_GetIter(result);
+        PyObject *item;
+
+        if (iterator == NULL) {
+            string msg = "The result of gradfcn(*arg) must be iterable \n"+graderrormsg(x);
+            warn_preserve_error(msg.c_str());
+            throw runtime_error(msg);
+        }
+
+        std::vector<double> result_vector;
+        while (item = PyIter_Next(iterator)) {
+            result_vector.push_back(PyFloat_AsDouble(item));
+            Py_DECREF(item);
+        }
+
+        Py_DECREF(iterator);
+
+        if((exc = PyErr_Occurred())){
+            string msg = "Cannot convert gradfcn(*arg) to a vector of doubles \n"+graderrormsg(x);
+            warn_preserve_error(msg.c_str());
+            throw runtime_error(msg);
+        }
+
+
+/*        double ret = PyFloat_AsDouble(result);
+        if((exc = PyErr_Occurred())){
+            string msg = "Cannot convert gradfcn(*arg) to double \n"+graderrormsg(x);
+            warn_preserve_error(msg.c_str());
+            throw runtime_error(msg);
+        }
+
+        if(ret!=ret){//check if nan
+            string msg = "gradfcn returns Nan\n"+graderrormsg(x);
+            warn_preserve_error(msg.c_str());
+            if(thrownan){
+                PyErr_SetString(PyExc_RuntimeError,msg.c_str());
+                throw runtime_error(msg.c_str());
+            }
+        }*/
+
+        Py_DECREF(tuple);
+        Py_DECREF(result);
+        ncall++;
+        return result_vector;
+    }
+
     //warn but do not reset the error flag
     inline void warn_preserve_error(const string& msg)const{
         PyObject *ptype,*pvalue,*ptraceback;
@@ -136,6 +157,21 @@ public:
 
     inline string errormsg(const std::vector<double>& x) const{
         string ret = "fcn is called with following arguments:\n";
+        assert(pname.size()==x.size());
+        //determine longest variable length
+        size_t maxlength = 0;
+        for(int i=0;i<x.size();i++){
+            maxlength = max(pname[i].size(),maxlength);
+        }
+        for(int i=0;i<x.size();i++){
+            string line = format("%*s = %+f\n",maxlength+4,pname[i].c_str(),x[i]);
+            ret += line;
+        }
+        return ret;
+    }
+
+    inline string graderrormsg(const std::vector<double>& x) const{
+        string ret = "gradfcn is called with following arguments:\n";
         assert(pname.size()==x.size());
         //determine longest variable length
         size_t maxlength = 0;

--- a/iminuit/PythonGradientFCN.h
+++ b/iminuit/PythonGradientFCN.h
@@ -124,26 +124,8 @@ public:
             throw runtime_error(msg);
         }
 
-
-/*        double ret = PyFloat_AsDouble(result);
-        if((exc = PyErr_Occurred())){
-            string msg = "Cannot convert gradfcn(*arg) to double \n"+graderrormsg(x);
-            warn_preserve_error(msg.c_str());
-            throw runtime_error(msg);
-        }
-
-        if(ret!=ret){//check if nan
-            string msg = "gradfcn returns Nan\n"+graderrormsg(x);
-            warn_preserve_error(msg.c_str());
-            if(thrownan){
-                PyErr_SetString(PyExc_RuntimeError,msg.c_str());
-                throw runtime_error(msg.c_str());
-            }
-        }*/
-
         Py_DECREF(tuple);
         Py_DECREF(result);
-        ncall++;
         return result_vector;
     }
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -277,6 +277,11 @@ cdef class Minuit:
               not callable iminuit will give a warning and set errordef to 1.
               Default None(which means errordef=1 with a warning).
 
+            - **grad_fcn**: Optional. Provide a function that calculates the
+              gradient analytically and returns an iterable object with one
+              element for each dimension. If None is given minuit will
+              calculate the gradient numerically. (Default None)
+
         **Parameter Keyword Arguments:**
 
             Similar to PyMinuit. iminuit allows user to set initial value,


### PR DESCRIPTION
This PR addresses #125 and #175 and adds the `grad_fcn` keyword  argument when initialising `Minuit`.

Example usage:
```python
def f(x, y, z):
    return 0.2 * (x - 2.) ** 2 + 0.1 * (y - 5.) ** 2 + 0.25 * (z - 7.) ** 2 + 10
def f_grad(x, y, z):
    dfdx = 0.4 * (x - 2.)
    dfdy = 0.2 * (y - 5.)
    dfdz = 0.5 * (z - 7.)
    return (dfdx, dfdy, dfdz)

m = Minuit(f, grad_fcn=f_grad)
m.migrad()
```