### PR TITLE
Support empty parameter lists in table-building

### DIFF
--- a/iminuit/frontends/console.py
+++ b/iminuit/frontends/console.py
@@ -109,7 +109,10 @@ class ConsoleFrontend:
         """
         merr = {} if merr is None else merr
         vnames = [mp.name for mp in mps]
-        maxlength = max([len(x) for x in vnames])
+        if vnames:
+            maxlength = max([len(x) for x in vnames])
+        else:
+            maxlength = 0
         maxlength = max(5, maxlength)
 
         header = (('| {0:^4s} | {1:^%ds} | {2:^8s} | {3:^8s} | {4:^8s} |'

--- a/iminuit/latex.py
+++ b/iminuit/latex.py
@@ -32,12 +32,22 @@ class LatexTable:
     def __init__(self, data, headers=None, smart_latex=True,
                  escape_under_score=True, alignment=None, rotate_header=False,
                  latex_map=None):
-        if headers is not None:
-            assert (len(headers) == len(data[0]))
+        # Make sure #data columns matches #header columns, using any non-zero
+        # length if data or headers are missing
+        if len(data) > 0:
+            num_col = len(data[0])
+            if headers:
+                assert num_col == len(headers)
+        else:
+            if headers is not None:
+                num_col = len(headers)
+            else:
+                # LaTeX requires at least one column
+                num_col = 1
 
         self.headers = headers
         self.data = data
-        self.num_col = len(data[0])
+        self.num_col = num_col
         self.smart_latex = smart_latex
         self.escape_under_score = escape_under_score
         self.alignment = self._auto_align() if alignment is None else alignment

--- a/iminuit/tests/test_latex.py
+++ b/iminuit/tests/test_latex.py
@@ -39,3 +39,25 @@ def test_format():
     ltt2 = LatexTable(data=[['alpha', 10.123, 20], ['alpha_s', 30, 40]],
                       smart_latex=False, escape_under_score=False)
     assert ltt2._format('a_b') == r'a_b'
+
+
+def test_empty_table():
+    ltt = LatexTable(data=[])
+    expected = '\n'.join([
+        r'\begin{tabular}{|c|}',
+        r'\hline',
+        r'\end{tabular}',
+    ])
+    assert str(ltt) == expected
+
+
+def test_empty_table_with_headers():
+    ltt = LatexTable(data=[], headers=['Foo', 'Bar'])
+    expected = '\n'.join([
+        r'\begin{tabular}{|c|c|}',
+        r'\hline',
+        r'Foo & Bar\\',
+        r'\hline',
+        r'\end{tabular}',
+    ])
+    assert str(ltt) == expected


### PR DESCRIPTION
Fixes #191.

I haven't added a test for the console bug fix. There don't appear to be any existing tests for the console tables, so rather than writing a lonely test I skipped it.