### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyxbldc
 *.root
 .DS_Store
 *.so

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,16 @@
 PROJECT = iminuit
 CYTHON ?= cython
 
+default_target: build
+
 help:
 	@echo ''
 	@echo ' iminuit available make targets:'
 	@echo ''
-	@echo '     help             Print this help message (the default)'
+	@echo '     help             Print this help message'
 	@echo ''
+	@echo '     build            Build inplace (the default)'
 	@echo '     clean            Remove generated files'
-	@echo '     build            Build inplace'
 	@echo '     test             Run tests'
 	@echo '     coverage         Run tests and write coverage report'
 	@echo '     cython           Compile cython files'
@@ -45,7 +47,9 @@ clean:
 	find . -name "*.so" -exec rm {} \;
 	find . -name __pycache__ | xargs rm -fr
 
-build:
+build: _libiminuit.so
+
+_libiminuit.so: $(wildcard Minuit/src/*.cxx Minuit/inc/*/*.h iminuit/*.pyx iminuit/*.pxi)
 	python setup.py build_ext --inplace
 
 test: build

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ compiler_opts = {
     CCompiler: dict(),
     UnixCCompiler: dict(extra_compile_args=[
             '-Wno-shorten-64-to-32', '-Wno-null-conversion',
-            '-Wno-parentheses', '-Wno-unused-variable'
+            '-Wno-parentheses', '-Wno-unused-variable', '-Wno-sign-compare',
         ]),
     MSVCCompiler: dict(),
 }


### PR DESCRIPTION
These patches make development more fluid and convenient. These are all backward-compatible improvements with no changes to users. All warnings should be gone now, if you use gcc or clang.

`make` now runs `make build`, not `make help`, which is most commonly what you want when you type `make`. I set the dependencies of the `build` target properly, so that the module is correctly rebuild when the sources change. This was not the case before.

I found a recipe on the internet to make setuptools use compiler-specific flags. This allows me to add flags for gcc and clang to ignore warnings in code generated by Cython and in the externally developed Minuit code. As it is, we cannot fix these warnings, they need to be fixed in the Cython code generator and the original Minuit source code. This is the best workaround for now.