### PR TITLE
dependency fix, improves performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ clean:
 	find . -name "*.so" -exec rm {} \;
 	find . -name __pycache__ | xargs rm -fr
 
-build: _libiminuit.so
+build: iminuit/_libiminuit.so
 
-_libiminuit.so: $(wildcard Minuit/src/*.cxx Minuit/inc/*/*.h iminuit/*.pyx iminuit/*.pxi)
+iminuit/_libiminuit.so: $(wildcard Minuit/src/*.cxx Minuit/inc/*/*.h iminuit/*.pyx iminuit/*.pxi)
 	python setup.py build_ext --inplace
 
 test: build


### PR DESCRIPTION
Forgot to put the correct paths. It works without, but `make` runs some superfluous commands if the dependencies are set incorrectly.