### PR TITLE
Sigma keyword for hesse

### DIFF
--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -446,7 +446,7 @@ cdef class Minuit:
 
         return self.get_fmin(), self.get_param_states()
 
-    def hesse(self):
+    def hesse(self, sigma=1):
         """Run HESSE.
 
         HESSE estimates error matrix by the `second derivative at the minimim
@@ -469,6 +469,8 @@ cdef class Minuit:
         if self.print_level > 0: self.frontend.print_banner('HESSE')
         if self.cfmin is NULL:
             raise RuntimeError('Run migrad first')
+        cdef double oldup = self.pyfcn.Up()
+        self.pyfcn.SetErrorDef(oldup * sigma * sigma)
         hesse = new MnHesse(self.strategy)
         if self.grad_fcn is None:
             upst = hesse.call(
@@ -492,6 +494,7 @@ cdef class Minuit:
             self.print_param()
             self.print_matrix()
 
+        self.pyfcn.SetErrorDef(oldup)
         return self.get_param_states()
 
     def minos(self, var = None, sigma = 1., unsigned int maxcall=1000):

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -459,6 +459,10 @@ cdef class Minuit:
         likelihood profile is utterly discontinuous near the minimum). But,
         it is much more computationally expensive.
 
+        **Arguments:**
+
+            - **sigma**: number of :math:`\sigma` error. Default 1.0.
+
         **Returns:**
 
             list of :ref:`minuit-param-struct`

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -237,6 +237,17 @@ def test_fitarg():
     assert fitarg['limit_x'] == (0, 20)
 
 
+def test_hesse_all():
+    m = Minuit(func3, pedantic=False, print_level=0)
+    m.migrad()
+    for sigma in range(1, 4):
+        m.hesse(sigma=sigma)
+        assert_allclose(m.errors['x'], sigma*sqrt(5))
+        assert_allclose(m.errors['y'], sigma*1.)
+        assert_allclose(m.covariance[("x", "x")], sigma**2 * 5)
+        assert_allclose(m.covariance[("y", "y")], sigma**2 * 1)
+        assert_allclose(m.covariance[("x", "y")], 0, atol=1e-8)
+
 def test_minos_all():
     m = Minuit(func3, pedantic=False, print_level=0)
     m.migrad()
@@ -510,11 +521,13 @@ def test_num_call():
     assert func.ncall ==  m.get_num_call_fcn()
 
 
-def test_set_error_def():
+def test_set_errordef():
     m = Minuit(lambda x: x**2, pedantic=False, print_level=0, errordef=1)
     m.migrad()
     m.hesse()
     assert_allclose(m.errors["x"], 1)
+    assert_allclose(m.covariance[("x", "x")], 1)
     m.set_errordef(4)
     m.hesse()
     assert_allclose(m.errors["x"], 2)
+    assert_allclose(m.covariance[("x", "x")], 4)


### PR DESCRIPTION
This addresses issue #173, by making `hesse(...)` and `minos(...)` accept a `sigma` keyword. The effect could be obtained in other ways, but most people do not understand how `set_errordef(...)` works, and I don't blame them, it is not obvious. I like the `sigma` keyword in `minos(...)`, because it is pretty clear.

People expect similar things to behave similarly, and hesse and minos are pretty similar. It therefore makes sense to have a similar interface.