### PR TITLE
numpy getters

### DIFF
--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -624,6 +624,16 @@ cdef class Minuit:
             a[i] = self.errors[k]
         return a
 
+    def np_merrors(self):
+        """Parameter errors in numpy array format."""
+        import numpy as np
+        # array format follows matplotlib conventions, see pyplot.errorbar
+        a = np.empty((2, len(self.parameters)), dtype=np.double)
+        for i, k in enumerate(self.parameters):
+            a[0, i] = -self.merrors[(k, -1.0)]
+            a[1, i] = self.merrors[(k, 1.0)]
+        return a
+
     def np_covariance(self):
         """Covariance matrix in numpy array format.
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -611,6 +611,35 @@ cdef class Minuit:
         matrix = self.matrix(correlation=correlation, skip_fixed=skip_fixed)
         return np.array(matrix, dtype=np.float64)
 
+    def np_values(self):
+        """Parameter values in numpy array format."""
+        import numpy as np
+        a = np.empty(len(self.parameters))
+        for i, k in enumerate(self.parameters):
+            a[i] = self.values[k]
+        return a
+
+    def np_errors(self):
+        """Parameter errors in numpy array format."""
+        import numpy as np
+        a = np.empty(len(self.parameters))
+        for i, k in enumerate(self.parameters):
+            a[i] = self.errors[k]
+        return a
+
+    def np_covariance(self):
+        """Covariance matrix in numpy array format.
+
+        Note that a ``numpy.ndarray`` is returned, not a ``numpy.matrix``
+        """
+        import numpy as np
+        n = len(self.parameters)
+        a = np.empty((n, n))
+        for i1, k1 in enumerate(self.parameters):
+            for i2, k2 in enumerate(self.parameters):
+                a[i1, i2] = self.covariance[(k1, k2)]
+        return a
+
     def is_fixed(self, vname):
         """Check if variable *vname* is (initially) fixed"""
         if vname not in self.parameters:

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -601,21 +601,38 @@ cdef class Minuit:
         """Error or correlation matrix in numpy array format.
 
         The name of this function was chosen to be analogous to :meth:`matrix`,
-        it returns the same information in a different format.
+        it returns the same information in a different format. For
+        documentation on the arguments, please see :meth:`matrix`.
 
-        Note that a ``numpy.ndarray`` is returned, not a ``numpy.matrix``
+        **Returns:**
+
+            2D ``numpy.ndarray`` of shape (N,N) (not a ``numpy.matrix``).
         """
         import numpy as np
         matrix = self.matrix(correlation=correlation, skip_fixed=skip_fixed)
         return np.array(matrix, dtype=np.double)
 
     def np_values(self):
-        """Parameter values in numpy array format."""
+        """Parameter values in numpy array format.
+
+        Fixed parameters are included, the order follows :attr:`parameters`.
+
+        **Returns:**
+
+            ``numpy.ndarray`` of shape (N,).
+         """
         import numpy as np
         return np.array(self.args, dtype=np.double)
 
     def np_errors(self):
-        """Hesse parameter errors in numpy array format."""
+        """Hesse parameter errors in numpy array format.
+
+        Fixed parameters are included, the order follows :attr:`parameters`.
+
+        **Returns:**
+
+            ``numpy.ndarray`` of shape (N,).
+        """
         import numpy as np
         a = np.empty(len(self.parameters), dtype=np.double)
         for i, k in enumerate(self.parameters):
@@ -623,7 +640,20 @@ cdef class Minuit:
         return a
 
     def np_merrors(self):
-        """Minos parameter errors in numpy array format."""
+        """Minos parameter errors in numpy array format.
+
+        Fixed parameters are included, the order follows :attr:`parameters`.
+
+        The format of the produced array follows matplotlib conventions, as
+        in ``matplotlib.pyplot.errorbar``. The shape is (2, N) for N
+        parameters. The first row represents the downward error as a positive
+        offset from the center. Likewise, the second row represents the
+        upward error as a positive offset from the center.
+
+        **Returns:**
+
+            ``numpy.ndarray`` of shape (2, N).
+        """
         import numpy as np
         # array format follows matplotlib conventions, see pyplot.errorbar
         a = np.empty((2, len(self.parameters)), dtype=np.double)
@@ -635,7 +665,11 @@ cdef class Minuit:
     def np_covariance(self):
         """Covariance matrix in numpy array format.
 
-        Note that a ``numpy.ndarray`` is returned, not a ``numpy.matrix``
+        Fixed parameters are included, the order follows :attr:`parameters`.
+
+        **Returns:**
+
+            ``numpy.ndarray`` of shape (N,N) (not a ``numpy.matrix``).
         """
         return self.np_matrix(correlation=False, skip_fixed=False)
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -614,15 +614,12 @@ cdef class Minuit:
     def np_values(self):
         """Parameter values in numpy array format."""
         import numpy as np
-        a = np.empty(len(self.parameters))
-        for i, k in enumerate(self.parameters):
-            a[i] = self.values[k]
-        return a
+        return np.asarray(self.args, dtype=np.double)
 
     def np_errors(self):
         """Parameter errors in numpy array format."""
         import numpy as np
-        a = np.empty(len(self.parameters))
+        a = np.empty(len(self.parameters), dtype=np.double)
         for i, k in enumerate(self.parameters):
             a[i] = self.errors[k]
         return a
@@ -634,7 +631,7 @@ cdef class Minuit:
         """
         import numpy as np
         n = len(self.parameters)
-        a = np.empty((n, n))
+        a = np.empty((n, n), dtype=np.double)
         for i1, k1 in enumerate(self.parameters):
             for i2, k2 in enumerate(self.parameters):
                 a[i1, i2] = self.covariance[(k1, k2)]

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -450,6 +450,27 @@ class TestMatrix:
         assert_allclose(actual, expected)
         assert isinstance(actual, np.ndarray)
 
+    def test_np_values(self):
+        import numpy as np
+        actual = self.m.np_values()
+        expected = [2., 5.]
+        assert_allclose(actual, expected)
+        assert isinstance(actual, np.ndarray)
+
+    def test_np_errors(self):
+        import numpy as np
+        actual = self.m.np_errors()
+        expected = [5.**0.5, 1.]
+        assert_allclose(actual, expected)
+        assert isinstance(actual, np.ndarray)
+
+    def test_np_covariance(self):
+        import numpy as np
+        actual = self.m.np_covariance()
+        expected = [[5., 0.], [0., 1.]]
+        assert_allclose(actual, expected)
+        assert isinstance(actual, np.ndarray)
+
     def test_matrix_correlation(self):
         actual = self.m.matrix(correlation=True)
         expected = [[1., 0.], [0., 1.]]

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -433,54 +433,68 @@ def test_reverse_limit():
         m.migrad()
 
 
-class TestMatrix:
+class TestOutputInterface:
     def setup(self):
         self.m = Minuit(func3, print_level=0, pedantic=False)
         self.m.migrad()
+        self.m.hesse()
+        self.m.minos()
+
+    def test_args(self):
+        actual = self.m.args
+        expected = [2., 5.]
+        assert_allclose(actual, expected, atol=1e-8)
 
     def test_matrix(self):
         actual = self.m.np_matrix()
         expected = [[5., 0.], [0., 1.]]
-        assert_allclose(actual, expected)
+        assert_allclose(actual, expected, atol=1e-8)
+
+    def test_matrix_correlation(self):
+        actual = self.m.matrix(correlation=True)
+        expected = [[1., 0.], [0., 1.]]
+        assert_allclose(actual, expected, atol=1e-8)
 
     def test_np_matrix(self):
         import numpy as np
         actual = self.m.np_matrix()
         expected = [[5., 0.], [0., 1.]]
-        assert_allclose(actual, expected)
+        assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
 
     def test_np_values(self):
         import numpy as np
         actual = self.m.np_values()
         expected = [2., 5.]
-        assert_allclose(actual, expected)
+        assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
 
     def test_np_errors(self):
         import numpy as np
         actual = self.m.np_errors()
         expected = [5.**0.5, 1.]
-        assert_allclose(actual, expected)
+        assert_allclose(actual, expected, atol=1e-8)
+        assert isinstance(actual, np.ndarray)
+
+    def test_np_merrors(self):
+        import numpy as np
+        actual = self.m.np_merrors()
+        expected = [[5.**0.5, 1.], [5.**0.5, 1.]]
+        assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
 
     def test_np_covariance(self):
         import numpy as np
         actual = self.m.np_covariance()
         expected = [[5., 0.], [0., 1.]]
-        assert_allclose(actual, expected)
+        assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
-
-    def test_matrix_correlation(self):
-        actual = self.m.matrix(correlation=True)
-        expected = [[1., 0.], [0., 1.]]
-        assert_allclose(actual, expected)
 
     def test_np_matrix_correlation(self):
         import numpy as np
         actual = self.m.np_matrix(correlation=True)
         expected = [[1., 0.], [0., 1.]]
-        assert_allclose(actual, expected)
+        assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
 
 

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -461,6 +461,7 @@ class TestOutputInterface:
         expected = [[5., 0.], [0., 1.]]
         assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
+        assert actual.shape == (2, 2)
 
     def test_np_values(self):
         import numpy as np
@@ -468,6 +469,7 @@ class TestOutputInterface:
         expected = [2., 5.]
         assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
+        assert actual.shape == (2,)
 
     def test_np_errors(self):
         import numpy as np
@@ -475,6 +477,7 @@ class TestOutputInterface:
         expected = [5.**0.5, 1.]
         assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
+        assert actual.shape == (2,)
 
     def test_np_merrors(self):
         import numpy as np
@@ -482,6 +485,7 @@ class TestOutputInterface:
         expected = [[5.**0.5, 1.], [5.**0.5, 1.]]
         assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
+        assert actual.shape == (2, 2)
 
     def test_np_covariance(self):
         import numpy as np
@@ -489,6 +493,7 @@ class TestOutputInterface:
         expected = [[5., 0.], [0., 1.]]
         assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
+        assert actual.shape == (2, 2)
 
     def test_np_matrix_correlation(self):
         import numpy as np
@@ -496,6 +501,7 @@ class TestOutputInterface:
         expected = [[1., 0.], [0., 1.]]
         assert_allclose(actual, expected, atol=1e-8)
         assert isinstance(actual, np.ndarray)
+        assert actual.shape == (2, 2)
 
 
 def test_chi2_fit():


### PR DESCRIPTION
Addresses issue #200 

The tuple-based attribute interface `values`, `errors`, `merrors`, and `covariance` is mirrored by numpy-friendly getters with the `np_` prefix. This adds a great deal of convenience for numpy users.