### PR TITLE
added missing doc rule; removed doc-show rule; make sphinx find local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ help:
 	@echo '     coverage         Run tests and write coverage report'
 	@echo '     cython           Compile cython files'
 	@echo '     doc              Run Sphinx to generate HTML docs'
-	@echo '     doc-show         Open local HTML docs in browser'
 	@echo ''
 	@echo '     code-analysis    Run code analysis (flake8 and pylint)'
 	@echo '     flake8           Run code analysis (flake8)'
@@ -62,8 +61,10 @@ coverage: build
 cython:
 	find $(PROJECT) -name "*.pyx" -exec $(CYTHON) --cplus  {} \;
 
-doc-show:
-	open doc/_build/html/index.html
+doc/_build/html/index.html: iminuit/_libiminuit.so $(wildcard doc/*.rst)
+	{ cd doc; make html; }
+
+doc: doc/_build/html/index.html
 
 code-analysis: flake8 pylint
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,12 @@
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+
+# Make sure local build of iminuit is found, if it is available
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__) + "/..")
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',


### PR DESCRIPTION
A "doc" rule was advertised in the "help", but not actually implemented. Now we have one, and it only rebuild the html docu if the source files changed.

I took the liberty to remove the "doc-show" rule, which only works on Mac.

Finally, I added a bit of code to doc/conf.py, which enables sphinx to find the locally build iminuit module. When you are developing, that is usually what you want. Before, you had to install iminuit at least user-wide just to generate the docs.