### PR TITLE
fix: detect and handle functions with variable length args

### DIFF
--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -287,8 +287,8 @@ cdef class Minuit:
 
         args = describe(fcn) if forced_parameters is None \
             else forced_parameters
+        self.narg = len(args)
         self._check_extra_args(args, kwds)
-        narg = len(args)
         self.fcn = fcn
         self.grad_fcn = grad_fcn
 
@@ -344,8 +344,6 @@ cdef class Minuit:
         self.fitarg.update({'error_' + k: v for k, v in self.initialerror.items()})
         self.fitarg.update({'limit_' + k: v for k, v in self.initiallimit.items()})
         self.fitarg.update({'fix_' + k: v for k, v in self.initialfix.items()})
-
-        self.narg = len(self.parameters)
 
         self.merrors_struct = {}
 

--- a/iminuit/tests/test_describe.py
+++ b/iminuit/tests/test_describe.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 from iminuit.util import describe
 from iminuit.tests.utils import requires_dependency
 from math import ldexp
+import pytest
 
 
 # simple function
@@ -68,6 +69,15 @@ def test_fakefunc():
 # builtin (parsing doc)
 def test_builtin():
     assert describe(ldexp, True) == ['x', 'i']
+
+
+def test_lambda():
+    assert describe(lambda a,b: 0, True) == ['a', 'b']
+
+
+def test_variadic():
+    with pytest.raises(TypeError):
+        describe(lambda *args: 0, True)
 
 
 @requires_dependency('Cython')

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -65,6 +65,10 @@ def func6(x, m, s, A):
     return A / ((x - m) ** 2 + s ** 2)
 
 
+def func7(*args): # no signature
+    return (args[0] - 1) ** 2 + (args[1] - 2) ** 2
+
+
 data_y = [0.552, 0.735, 0.846, 0.875, 1.059, 1.675, 1.622, 2.928,
           3.372, 2.377, 4.307, 2.784, 3.328, 2.143, 1.402, 1.44,
           1.313, 1.682, 0.886, 0.0, 0.266, 0.3]
@@ -102,6 +106,17 @@ def test_f3():
 
 def test_lambda():
     functesthelper(lambda x, y: (x - 2.) ** 2 + (y - 5.) ** 2 + 10)
+
+
+def test_nosignature():
+    with pytest.raises(TypeError):
+        Minuit(func7)
+    m = Minuit(func7, forced_parameters=('x', 'y'),
+               pedantic=False, print_level=0)
+    m.migrad()
+    val = m.values
+    assert_allclose((val['x'], val['y'], m.fval), (1, 2, 0), atol=1e-8)
+    assert m.migrad_ok()
 
 
 def test_typo():

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -100,13 +100,12 @@ def arguments_from_funccode(f):
     """
     fc = fc_or_c(f)
     vnames = fc.co_varnames
+    nargs = fc.co_argcount
     # bound method and fake function will be None
-    if is_bound(f):
-        # bound method dock off self
-        return list(vnames[1:fc.co_argcount])
-    else:
-        # unbound and fakefunc
-        return list(vnames[:fc.co_argcount])
+    args = vnames[1:nargs] if is_bound(f) else vnames[:nargs]
+    if not args:
+        raise RuntimeError('Function has variable number of arguments')
+    return list(args)
 
 
 def arguments_from_call_funccode(f):

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -102,7 +102,7 @@ def arguments_from_funccode(f):
     vnames = fc.co_varnames
     nargs = fc.co_argcount
     # bound method and fake function will be None
-    args = vnames[1:nargs] if is_bound(f) else vnames[:nargs]
+    args = vnames[1 if is_bound(f) else 0:nargs]
     if not args:
         raise RuntimeError('Function has variable number of arguments')
     return list(args)


### PR DESCRIPTION
`describe` did not fail on functions with variable length args, while it should. Since it did not raise an error, Minuit later fails with an obscure error message when you try to call `migrad`.

Now an error is correctly raised by `describe` and the cases are tested.