### PR TITLE
Fix cython dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ matrix:
 before_install:
   - pip install setuptools numpy cython
   - if [[ $BUILD == NO_CYTHON ]]; then
-      python setup.py sdist # use this to generate cpp files from pyx files
-      pip uninstall cython
+      python setup.py sdist; # use this to generate cpp files from pyx files
+      pip uninstall cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
 
 before_install:
   - pip install setuptools Cython
+  - if [[ $BUILD != NO_CYTHON ]]; then
+      pip install sdist;
+      pip uninstall cython;
+    fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
   - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - pip install setuptools Cython
   - if [[ $BUILD == NO_CYTHON ]]; then
       python setup.py sdist;
-      pip uninstall cython;
+      pip uninstall -y cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
 before_install:
   - pip install setuptools Cython
-  - if [[ $BUILD != NO_CYTHON ]]; then
+  - if [[ $BUILD == NO_CYTHON ]]; then
       python setup.py sdist;
       pip uninstall cython;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ install:
 script:
   - if [[ $BUILD == TEST ]]; then make test; fi
   - if [[ $BUILD == COVERAGE ]]; then make coverage; fi
-  - if [[ $BUILD == DOCS ]]; then cd doc; sphinx-build -W -a -E -b html -d _build/doctrees . _build/html; fi
+  - if [[ $BUILD == DOCS ]]; then make doc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - python: 2.7
           env: BUILD=DOCS
 
-        - python: 3.4
+        - python: 3.5
           env: BUILD=DOCS
 
         - python: 3.5
@@ -31,12 +31,18 @@ matrix:
         - python: 3.5
           env: BUILD=NO_EXTRA_DEPS
 
+        - python: 3.5
+          env: BUILD=NO_CYTHON
 
 before_install:
-  - pip install setuptools Cython
-  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
+  - pip install setuptools numpy cython
+  - if [[ $BUILD == NO_CYTHON ]]; then
+      python setup.py sdist # use this to generate cpp files from pyx files
+      pip uninstall cython
+    fi
+  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
-  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov; fi
 
 install:
   - python setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,32 +5,21 @@ sudo: false
 matrix:
     include:
         - python: 2.7
-          env: BUILD=TEST
-
-        - python: 3.4
-          env: BUILD=TEST
+          env:
+            - BUILD=TEST
+            - BUILD=DOCS
 
         - python: 3.5
-          env: BUILD=TEST
+          env:
+            - BUILD=TEST
+            - BUILD=DOCS
+            - BUILD=COVERAGE
+            - BUILD=NO_EXTRA_DEPS
+            - BUILD=NO_CYTHON
 
         # TODO: add tests on Mac
 
         # TODO: add tests for Python from conda
-
-        - python: 2.7
-          env: BUILD=DOCS
-
-        - python: 3.4
-          env: BUILD=DOCS
-
-        - python: 3.5
-          env: BUILD='COVERAGE'
-
-        - python: 3.5
-          env: BUILD=NO_EXTRA_DEPS
-
-        - python: 3.5
-          env: BUILD=NO_CYTHON
 
 before_install:
   - pip install setuptools Cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
         - python: 3.5
           env: BUILD=TEST
 
+        # TODO: add tests for installed version!!
+
         # TODO: add tests on Mac
 
         # TODO: add tests for Python from conda
@@ -20,7 +22,7 @@ matrix:
         - python: 2.7
           env: BUILD=DOCS
 
-        - python: 3.5
+        - python: 3.4
           env: BUILD=DOCS
 
         - python: 3.5
@@ -29,18 +31,12 @@ matrix:
         - python: 3.5
           env: BUILD=NO_EXTRA_DEPS
 
-        - python: 3.5
-          env: BUILD=NO_CYTHON
 
 before_install:
-  - pip install setuptools numpy cython
-  - if [[ $BUILD == NO_CYTHON ]]; then
-      python setup.py sdist; # use this to generate cpp files from pyx files
-      pip uninstall cython;
-    fi
-  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython matplotlib; fi
+  - pip install setuptools Cython
+  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
   - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
-  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi
 
 install:
   - python setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
         - python: 3.5
           env: BUILD=TEST
 
-        # TODO: add tests for installed version!!
-
         # TODO: add tests on Mac
 
         # TODO: add tests for Python from conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,25 @@ sudo: false
 matrix:
     include:
         - python: 2.7
-          env:
-            - BUILD=TEST
-            - BUILD=DOCS
+          env: BUILD=TEST
+
+        - python: 2.7
+          env: BUILD=DOCS
 
         - python: 3.5
-          env:
-            - BUILD=TEST
-            - BUILD=DOCS
-            - BUILD=COVERAGE
-            - BUILD=NO_EXTRA_DEPS
-            - BUILD=NO_CYTHON
+          env: BUILD=TEST
+
+        - python: 3.5
+          env: BUILD=DOCS
+
+        - python: 3.5
+          env: BUILD=COVERAGE
+
+        - python: 3.5
+          env: BUILD=NO_EXTRA_DEPS
+
+        - python: 3.5
+          env: BUILD=NO_CYTHON
 
         # TODO: add tests on Mac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
         - python: 3.5
           env: BUILD=TEST
 
-        # TODO: add tests for installed version!!
-
         # TODO: add tests on Mac
 
         # TODO: add tests for Python from conda
@@ -31,6 +29,8 @@ matrix:
         - python: 3.5
           env: BUILD=NO_EXTRA_DEPS
 
+        - python: 3.5
+          env: BUILD=NO_CYTHON
 
 before_install:
   - pip install setuptools Cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 before_install:
   - pip install setuptools Cython
   - if [[ $BUILD != NO_CYTHON ]]; then
-      pip install sdist;
+      python setup.py sdist;
       pip uninstall cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build htmlcov doc/_build
+	rm -rf build htmlcov doc/_build iminuit/_libiminuit.cpp
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find . -name __pycache__ | xargs rm -fr

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,16 @@ try:
 
     USE_CYTHON = True  # TODO: add command line option?
 except ImportError:
-    print('Cython is not available ... using pre-generated C file.')
     USE_CYTHON = False
+    if exists('iminuit/_libiminuit.cpp'):
+        print('Cython is not available ... using pre-generated cpp file.')
+    else:
+        raise SystemExit('Looks like you are trying to install iminuit '
+                         'from github. This requires Cython. Run\n'
+                         '   pip install cython\n'
+                         'for a system-wide installation, or\n'
+                         '   pip install --user cython\n'
+                         'for a user-wide installation.')
 
 ext = '.pyx' if USE_CYTHON else '.cpp'
 

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,11 @@ except ImportError:
 
 ext = '.pyx' if USE_CYTHON else '.cpp'
 
-import numpy
-numpy_header = [numpy.get_include()]
+try:
+    import numpy
+    numpy_header = [numpy.get_include()]
+except ImportError:
+    numpy_header = []
 
 libiminuit = Extension('iminuit._libiminuit',
                        sources=(glob(join(cwd, 'iminuit/*'+ext)) + minuit_src),

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
     extras_require={
         'all': ['ipython', 'matplotlib'],
     },
-    tests_require=['pytest', 'pytest-cov', 'numpy', 'scipy'],
+    tests_require=['pytest', 'pytest-cov', 'numpy', 'scipy', 'matplotlib'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -40,25 +40,6 @@ class SmartBuildExt(build_ext):
         build_ext.build_extensions(self)
 
 
-# http://pytest.org/latest/goodpractices.html#manual-integration
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        # self.pytest_args = '--pyargs iminuit'
-        # self.pytest_args = ['--strict', '--verbose', '--tb=long', 'tests']
-        self.pytest_args = ''
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        import shlex
-        errno = pytest.main(shlex.split(self.pytest_args))
-        del sys.exitfunc # needed to avoid a bug caused by IPython's exitfunc
-        sys.exit(errno)
-
-
 def lazy_compile(self, sources, output_dir=None, macros=None,
                  include_dirs=None, debug=0, extra_preargs=None,
                  extra_postargs=None, depends=None):
@@ -149,10 +130,6 @@ setup(
     packages=['iminuit', 'iminuit.frontends', 'iminuit.tests'],
     ext_modules=extensions,
     install_requires=['setuptools', 'numpy'],
-    extras_require={
-        'all': ['ipython', 'matplotlib'],
-    },
-    tests_require=['pytest', 'pytest-cov', 'numpy', 'scipy', 'matplotlib', 'IPython<6'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
@@ -171,7 +148,6 @@ setup(
         'License :: OSI Approved :: MIT License'
     ],
     cmdclass={
-        'test': PyTest,
         # 'coverage': CoverageCommand,
         'build_ext': SmartBuildExt,
     }

--- a/setup.py
+++ b/setup.py
@@ -97,11 +97,11 @@ except ImportError:
     if exists('iminuit/_libiminuit.cpp'):
         print('Cython is not available ... using pre-generated cpp file.')
     else:
-        raise SystemExit('Looks like you are trying to install iminuit '
-                         'from github. This requires Cython. Run\n'
-                         '   pip install cython\n'
-                         'for a system-wide installation, or\n'
-                         '   pip install --user cython\n'
+        raise SystemExit('Looks like you are installing iminuit from github.'
+                         'This requires Cython. Run\n\n'
+                         '   pip install cython\n\n'
+                         'for a system-wide installation, or\n\n'
+                         '   pip install --user cython\n\n'
                          'for a user-wide installation.')
 
 ext = '.pyx' if USE_CYTHON else '.cpp'

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
     extras_require={
         'all': ['ipython', 'matplotlib'],
     },
-    tests_require=['pytest', 'pytest-cov', 'numpy', 'scipy', 'matplotlib'],
+    tests_require=['pytest', 'pytest-cov', 'numpy', 'scipy', 'matplotlib', 'IPython<6'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -102,8 +102,7 @@ import numpy
 numpy_header = [numpy.get_include()]
 
 libiminuit = Extension('iminuit._libiminuit',
-                       sources=(glob(join(cwd, 'iminuit/*.pyx')) +
-                                minuit_src),
+                       sources=(glob(join(cwd, 'iminuit/*'+ext)) + minuit_src),
                        include_dirs=minuit_header + numpy_header)
 extensions = [libiminuit]
 


### PR DESCRIPTION
This is a fix for #234. Instead of just throwing an error, display a helpful error message if cython is not available. Also fixes installation of iminuit without Cython if the pregenerated cpp file is actually there. This used to work and got broken. We need this for the next release.