### PR TITLE
Implement or remove get_initial_param_state

### DIFF
--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -957,10 +957,6 @@ cdef class Minuit:
         """Dictionary of varname-> MinosError Struct"""
         return self.merrors_struct
 
-    def get_initial_param_state(self):
-        """Initial setting in form of MinuitParameter Struct"""
-        raise NotImplementedError
-
     def get_num_call_fcn(self):
         """Total number of calls to FCN (not just the last operation)"""
         cdef IMinuitMixinPtr ptr = dynamic_cast[IMinuitMixinPtr](self.pyfcn)


### PR DESCRIPTION
This is currently exposed by the API, but not yet implemented:

``` python
>>> from iminuit import Minuit
>>> def f(x, y, z):
...         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
... 
>>> m = Minuit(f, pedantic=False)
>>> m.get_param_states()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "iminuit/_libiminuit.pyx", line 718, in iminuit._libiminuit.Minuit.get_param_states (iminuit/_libiminuit.cpp:10274)
    if self.last_upst is NULL:
  File "iminuit/_libiminuit.pyx", line 732, in iminuit._libiminuit.Minuit.get_initial_param_state (iminuit/_libiminuit.cpp:10454)
    """Initial setting in form of MinuitParameter Struct"""
NotImplementedError
```

@piti118 – Can you fix this or comment what should be done? (I'm still not familiar with the Minuit code base ... slowly learning)
