### PR TITLE
Issue 163 get initial param state

### DIFF
--- a/iminuit/Minuit2Struct.pxi
+++ b/iminuit/Minuit2Struct.pxi
@@ -32,8 +32,8 @@ cdef minuitparam2struct(MinuitParameter mp):
         has_limits=mp.HasLimits(),
         has_lower_limit=mp.HasLowerLimit(),
         has_upper_limit=mp.HasUpperLimit(),
-        lower_limit=mp.LowerLimit(),
-        upper_limit=mp.UpperLimit(),
+        lower_limit=mp.LowerLimit() if mp.HasLowerLimit() else None,
+        upper_limit=mp.UpperLimit() if mp.HasUpperLimit() else None,
     )
     return ret
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -865,10 +865,10 @@ cdef class Minuit:
         sfmin = cfmin2struct(self.cfmin)
         ncalls = 0 if self.pyfcn is NULL else dynamic_cast[IMinuitMixinPtr](self.pyfcn).getNumCall()
 
-        self.frontend.print_hline(86)
+        self.frontend.print_hline()
         self.frontend.print_fmin(sfmin, self.tol, ncalls)
         self.print_param()
-        self.frontend.print_hline(86)
+        self.frontend.print_hline()
 
     def print_all_minos(self):
         """Print all minos errors (and its states)"""

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -837,9 +837,7 @@ cdef class Minuit:
 
         Extra keyword arguments will be passed to frontend.print_param.
         """
-        if self.last_upst is NULL:
-            self.print_initial_param(**kwds)
-            return
+        # fetches the initial state if migrad was not run
         p = self.get_param_states()
         self.frontend.print_param(p, self.merrors_struct, **kwds)
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -389,8 +389,8 @@ cdef class Minuit:
 
 
     @classmethod
-    def from_array_func(cls, fcn, start, error=None,
-                        limit=None, fix=None, name=None, **kwds):
+    def from_array_func(cls, fcn, start, error=None, limit=None, fix=None,
+                        name=None, **kwds):
         """
         Construct minuit object from given *fcn* and start sequence.
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -848,12 +848,12 @@ cdef class Minuit:
 
     def print_initial_param(self, **kwds):
         """Print initial parameters"""
-        p = self.get_param_states(initial=True)
+        p = self.get_initial_param_states()
         self.frontend.print_param(p, {}, **kwds)
 
     def latex_initial_param(self):
         """Build :class:`iminuit.latex.LatexTable` for initial parameter"""
-        p = self.get_param_states(initial=True)
+        p = self.get_initial_param_states()
         return LatexFactory.build_param_table(p, {})
 
     def print_fmin(self):
@@ -919,12 +919,17 @@ cdef class Minuit:
 
     # Expose internal state using various structs
 
-    def get_param_states(self, initial=False):
+    def get_param_states(self):
         """List of current MinuitParameter Struct for all parameters"""
-        if self.last_upst is NULL or initial == True:
-            up = self.initialParameterState()
-        else:
-            up = self.last_upst
+        if self.last_upst is NULL:
+            return self.get_initial_param_states()
+        up = self.last_upst
+        cdef vector[MinuitParameter] vmps = up.MinuitParameters()
+        return [minuitparam2struct(vmps[i]) for i in range(vmps.size())]
+
+    def get_initial_param_states(self):
+        """List of current MinuitParameter Struct for all parameters"""
+        up = self.initialParameterState()
         cdef vector[MinuitParameter] vmps = up.MinuitParameters()
         return [minuitparam2struct(vmps[i]) for i in range(vmps.size())]
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -184,10 +184,10 @@ cdef class Minuit:
     TODO: link to description.
     """
 
-    def __init__(self, fcn, grad_fcn=None,
+    def __init__(self, fcn,
                  throw_nan=False, pedantic=True,
                  frontend=None, forced_parameters=None, print_level=1,
-                 errordef=None, use_array_call=False,
+                 errordef=None, grad_fcn=None, use_array_call=False,
                  **kwds):
         """
         Construct minuit object from given *fcn*
@@ -389,7 +389,7 @@ cdef class Minuit:
 
 
     @classmethod
-    def from_array_func(cls, fcn, start, grad_fcn=None, error=None,
+    def from_array_func(cls, fcn, start, error=None,
                         limit=None, fix=None, name=None, **kwds):
         """
         Construct minuit object from given *fcn* and start sequence.
@@ -454,9 +454,8 @@ cdef class Minuit:
         """
         npar = len(start)
         pnames = name if name is not None else ["x%i"%i for i in range(npar)]
-        kwds['forced_parameters'] = pnames
-        kwds['use_array_call'] = True
-        kwds['grad_fcn'] = grad_fcn
+        kwds["forced_parameters"] = pnames
+        kwds["use_array_call"] = True
         if error is not None:
             if np.isscalar(error):
                 error = np.ones(npar) * error

--- a/iminuit/frontends/console.py
+++ b/iminuit/frontends/console.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division, unicode_literals)
+from __future__ import (absolute_import, division)
 import sys
 from .frontend import Frontend
 from math import log10
@@ -46,7 +46,7 @@ class ConsoleFrontend(Frontend):
             'Above EDM',
             '',
             'Reach calllim')
-        status2 = '|' + (' %14r |' * 5) % (
+        status2 = '|' + (' %14s |' * 5) % (
             fmin.hesse_failed,
             fmin.has_covariance,
             fmin.is_above_max_edm,

--- a/iminuit/frontends/console.py
+++ b/iminuit/frontends/console.py
@@ -169,5 +169,5 @@ class ConsoleFrontend(Frontend):
         tab.append(hline)
         self.display(*tab)
 
-    def print_hline(self, width=70):
+    def print_hline(self, width=86):
         self.display('*' * width)

--- a/iminuit/frontends/console.py
+++ b/iminuit/frontends/console.py
@@ -1,102 +1,96 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, unicode_literals)
+import sys
+from .frontend import Frontend
+from math import log10
 
 __all__ = ['ConsoleFrontend']
 
 
-class ConsoleFrontend:
+class ConsoleFrontend(Frontend):
     """Console frontend for Minuit.
 
     This class prints stuff directly via print.
     """
 
-    @staticmethod
-    def print_fmin(sfmin, tolerance=None, ncalls=0):
+    def display(self, *args):
+        sys.stdout.write('\n'.join(args)+'\n')
+
+    def print_fmin(self, fmin, tolerance=None, ncalls=0):
         """display function minimum information
         for FunctionMinimumStruct *sfmin*.
         It contains various migrad status.
         """
-        fmin = sfmin
         goaledm = 0.0001 * tolerance * fmin.up if tolerance is not None else ''
         # despite what the doc said the code is actually 1e-4
         # http://wwwasdoc.web.cern.ch/wwwasdoc/hbook_html3/node125.html
-        flatlocal = dict(list(locals().items()) + list(fmin.__dict__.items()))
-        info1 = 'fval = %(fval)r | total call = %(ncalls)r | ncalls = %(nfcn)r\n' % \
+        flatlocal = dict(list(locals().items()) + list(fmin.items()))
+        info1 = 'fval = %(fval)r | total call = %(ncalls)r | ncalls = %(nfcn)r' % \
                 flatlocal
-        info2 = 'edm = %(edm)r (Goal: %(goaledm)r) | up = %(up)r\n' % flatlocal
+        info2 = 'edm = %(edm)s (Goal: %(goaledm)s) | up = %(up)r' % flatlocal
         header1 = '|' + (' %14s |' * 5) % (
             'Valid',
             'Valid Param',
             'Accurate Covar',
             'Posdef',
-            'Made Posdef') + '\n'
-        hline = '-' * len(header1) + '\n'
+            'Made Posdef')
+        hline = '-' * len(header1)
         status1 = '|' + (' %14r |' * 5) % (
             fmin.is_valid,
             fmin.has_valid_parameters,
             fmin.has_accurate_covar,
             fmin.has_posdef_covar,
-            fmin.has_made_posdef_covar) + '\n'
+            fmin.has_made_posdef_covar)
         header2 = '|' + (' %14s |' * 5) % (
             'Hesse Fail',
             'Has Cov',
             'Above EDM',
             '',
-            'Reach calllim') + '\n'
+            'Reach calllim')
         status2 = '|' + (' %14r |' * 5) % (
             fmin.hesse_failed,
             fmin.has_covariance,
             fmin.is_above_max_edm,
             '',
-            fmin.has_reached_call_limit) + '\n'
+            fmin.has_reached_call_limit)
 
-        print(hline + info1 + info2 +
-              hline + header1 + hline + status1 +
-              hline + header2 + hline + status2 +
-              hline)
+        self.display(hline, info1, info2,
+                hline, header1, hline, status1,
+                hline, header2, hline, status2,
+                hline)
 
-    @staticmethod
-    def print_merror(vname, smerr):
+    def print_merror(self, vname, smerr):
         """print minos error for varname"""
         stat = 'VALID' if smerr.is_valid else 'PROBLEM'
 
-        summary = 'Minos Status for %s: %s\n' % \
+        summary = 'Minos Status for %s: %s' % \
                   (vname, stat)
 
-        error = '| {0:^15s} | {1: >12g} | {2: >12g} |\n'.format(
+        error = '| {0:^15s} | {1:^12g} | {2:^12g} |'.format(
             'Error',
             smerr.
                 lower,
             smerr.upper)
-        valid = '| {0:^15s} | {1:^12s} | {2:^12s} |\n'.format(
+        valid = '| {0:^15s} | {1:^12s} | {2:^12s} |'.format(
             'Valid',
             str(smerr.lower_valid),
             str(smerr.upper_valid))
-        at_limit = '| {0:^15s} | {1:^12s} | {2:^12s} |\n'.format(
+        at_limit = '| {0:^15s} | {1:^12s} | {2:^12s} |'.format(
             'At Limit',
             str(smerr.at_lower_limit),
             str(smerr.at_upper_limit))
-        max_fcn = '| {0:^15s} | {1:^12s} | {2:^12s} |\n'.format(
+        max_fcn = '| {0:^15s} | {1:^12s} | {2:^12s} |'.format(
             'Max FCN',
             str(smerr.at_lower_max_fcn),
             str(smerr.at_upper_max_fcn))
-        new_min = '| {0:^15s} | {1:^12s} | {2:^12s} |\n'.format(
+        new_min = '| {0:^15s} | {1:^12s} | {2:^12s} |'.format(
             'New Min',
             str(smerr.lower_new_min),
             str(smerr.upper_new_min))
-        hline = '-' * len(error) + '\n'
-        print(hline +
-              summary +
-              hline +
-              error +
-              valid +
-              at_limit +
-              max_fcn +
-              new_min +
-              hline)
+        hline = '-' * len(error)
+        self.display(hline, summary, hline, error, valid,
+                at_limit, max_fcn, new_min, hline)
 
-    @staticmethod
-    def print_param(mps, merr=None, float_format=None):
+    def print_param(self, mps, merr=None, float_format=None):
         """Print parameter states
 
         Arguments:
@@ -109,24 +103,25 @@ class ConsoleFrontend:
         """
         merr = {} if merr is None else merr
         vnames = [mp.name for mp in mps]
-        if vnames:
-            maxlength = max([len(x) for x in vnames])
-        else:
-            maxlength = 0
-        maxlength = max(5, maxlength)
+        name_width = max([len(x) for x in vnames]) if vnames else 0
+        name_width = max(4, name_width)
+        num_max = len(vnames)-1
+        num_width = max(2, int(log10(num_max)) + 1)
 
-        header = (('| {0:^4s} | {1:^%ds} | {2:^8s} | {3:^8s} | {4:^8s} |'
-                   ' {5:^8s} | {6:^8s} | {7:^8s} | {8:^8s} |\n') % maxlength).format(
-            '', 'Name', 'Value', 'Para Err',
-            "Err-", "Err+", "Limit-", "Limit+", " ")
-        hline = '-' * len(header) + '\n'
-        linefmt = ('| {0:>4d} | {1:>%ds} = {2:<8s} | {3:<8s} | {4:<8s} |'
-                   ' {5:<8s} | {6:<8s} | {7:<8s} | {8:^8s} |\n') % maxlength
-        nfmt = '{0:< 8.4G}'
+        header = (('| {0:^%is} | {1:^%is} | {2:^8s} | {3:^8s} | {4:^8s} |'
+                   ' {5:^8s} | {6:8s} | {7:8s} | {8:^6s} |') %
+                  (num_width, name_width)).format(
+            'No', 'Name', 'Value', 'Para Err',
+            "Err-", "Err+", "Limit-", "Limit+", "Fixed?")
+        hline = '-' * len(header)
+        linefmt = (('| {0:>%id} | {1:>%is} | {2:<8s} | {3:<8s} | {4:<8s} |'
+                    ' {5:<8s} | {6:8s} | {7:8s} | {8:^6s} |') %
+                   (num_width, name_width))
+        nfmt = '{0:<8.4G}'
         nformat = nfmt.format
         blank = ' ' * 8
 
-        ret = hline + header + hline
+        tab = [hline, header, hline]
         for i, (v, mp) in enumerate(zip(vnames, mps)):
             tmp = [i, v]
 
@@ -140,23 +135,20 @@ class ConsoleFrontend:
             tmp.append(nformat(mp.upper_limit) if mp.has_lower_limit else blank)
 
             tmp.append(
-                'FIXED' if mp.is_fixed else 'CONST' if mp.is_const else '')
+                'Yes' if mp.is_fixed else 'CONST' if mp.is_const else 'No')
 
             line = linefmt.format(*tmp)
-            ret += line
-        ret += hline
-        print(ret)
+            tab.append(line)
+        tab.append(hline)
+        self.display(*tab)
 
-    @staticmethod
-    def print_banner(cmd):
+    def print_banner(self, cmd):
         """show banner of command"""
-        ret = '*' * 50 + '\n'
-        ret += '*{:^48}*'.format(cmd) + '\n'
-        ret += '*' * 50 + '\n'
-        print(ret)
+        hline = '*' * 50
+        migrad = '*{:^48}*'.format(cmd)
+        self.display(hline, migrad, hline+'\n')
 
-    @staticmethod
-    def print_matrix(vnames, matrix):
+    def print_matrix(self, vnames, matrix):
         """TODO: properly implement this"""
         maxlen = max(len(v) for v in vnames)
         narg = len(matrix)
@@ -164,20 +156,17 @@ class ConsoleFrontend:
         vblank = ' ' * maxlen
         fmt = '%3.2f '  # 4char
         dfmt = '%4d '
-        tmp = ''
-        header = vblank + ' ' * 4 + '  | ' + (dfmt * narg) % tuple(range(narg)) + '\n'
-        tmp += '-' * len(header) + '\n'
-        tmp += 'Correlation\n'
-        tmp += '-' * len(header) + '\n'
-        blank_line = '-' * len(header) + '\n'
-        tmp += header + blank_line
+        header = vblank + ' ' * 4 + '  | ' + (dfmt * narg) % tuple(range(narg))
+        hline = '-' * len(header)
+        title = 'Correlation'
+        tab = [hline, title, hline, header, hline]
         for i, (v, row) in enumerate(zip(vnames, matrix)):
             fmt = '%3.2f ' * narg
             head = (vfmt + ' %4d | ') % (v, i)
-            content = (fmt) % tuple(row) + '\n'
-            tmp += head + content
-        tmp += blank_line
-        print(tmp)
+            content = (fmt) % tuple(row)
+            tab.append(head + content)
+        tab.append(hline)
+        self.display(*tab)
 
-    def print_hline(self):
-        print('*' * 70)
+    def print_hline(self, width=70):
+        self.display('*' * width)

--- a/iminuit/frontends/console.py
+++ b/iminuit/frontends/console.py
@@ -1,4 +1,5 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 import sys
 from .frontend import Frontend
 from math import log10

--- a/iminuit/frontends/frontend.py
+++ b/iminuit/frontends/frontend.py
@@ -1,0 +1,20 @@
+from ..py23_compat import ABC
+from abc import abstractmethod
+
+__all__ = ['Frontend']
+
+class Frontend(ABC):
+    @abstractmethod
+    def print_fmin(self): pass
+    @abstractmethod
+    def print_merror(self, vname, smerr): pass
+    @abstractmethod
+    def print_param(self, mps, merr=None, float_format=None): pass
+    @abstractmethod
+    def print_banner(self, cmd): pass
+    @abstractmethod
+    def print_matrix(self, vnames, matrix): pass
+    @abstractmethod
+    def print_hline(self, width=None): pass
+    @abstractmethod
+    def display(self, *args): pass

--- a/iminuit/frontends/html.py
+++ b/iminuit/frontends/html.py
@@ -5,6 +5,7 @@ import string
 from iminuit.util import Struct
 from iminuit.latex import LatexFactory
 from iminuit.color import Gradient
+from .frontend import Frontend
 
 __all__ = ['HtmlFrontend']
 
@@ -36,8 +37,8 @@ def fmin_style(sfmin):
     )
 
 
-def randid():
-    return ''.join(random.choice(string.ascii_letters) for _ in range(10))
+def randid(rng):
+    return ''.join(rng.choice(string.ascii_letters) for _ in range(10))
 
 
 def minos_style(smerr):
@@ -55,108 +56,105 @@ def minos_style(smerr):
     )
 
 
-class HtmlFrontend:
+class HtmlFrontend(Frontend):
     """HTML frontend for Minuit.
     """
 
-    @staticmethod
-    def print_fmin(sfmin, tolerance=None, ncalls=0):
+    rng = random.Random()
+
+
+    def display(self, *args):
+        from IPython.core.display import display_html
+        display_html(*args, raw=True)
+
+
+    def print_fmin(self, sfmin, tolerance=None, ncalls=0):
         """Display FunctionMinum in html representation.
 
         .. note: Would appreciate if someone would make jquery hover
         description for each item."""
-        from IPython.core.display import display_html
         goaledm = 0.0001 * tolerance * sfmin.up
         style = fmin_style(sfmin)
-        header = u"""
-        <table>
-            <tr>
-                <td title="Minimum value of function">FCN = {sfmin.fval}</td>
-                <td title="Total number of call to FCN so far">TOTAL NCALL = {ncalls}</td>
-                <td title="Number of call in last migrad">NCALLS = {sfmin.nfcn}</td>
-            </tr>
-            <tr>
-                <td title="Estimated distance to minimum">EDM = {sfmin.edm}</td>
-                <td title="Maximum EDM definition of convergence">GOAL EDM = {goaledm}</td>
-                <td title="Error def. Amount of increase in FCN to be defined as 1 standard deviation">
-                UP = {sfmin.up}</td>
-            </tr>
-        </table>
-        """.format(**locals())
-        status = u"""
-        <table>
-            <tr>
-                <td align="center" title="Validity of the migrad call">Valid</td>
-                <td align="center" title="Validity of parameters">Valid Param</td>
-                <td align="center" title="Is Covariance matrix accurate?">Accurate Covar</td>
-                <td align="center" title="Positive definiteness of covariance matrix">PosDef</td>
-                <td align="center" title="Was covariance matrix made posdef by adding diagonal element">Made PosDef</td>
-            </tr>
-            <tr>
-                <td align="center" style="{style.is_valid}">{sfmin.is_valid!r}</td>
-                <td align="center" style="{style.has_valid_parameters}">{sfmin.has_valid_parameters!r}</td>
-                <td align="center" style="{style.has_accurate_covar}">{sfmin.has_accurate_covar!r}</td>
-                <td align="center" style="{style.has_posdef_covar}">{sfmin.has_posdef_covar!r}</td>
-                <td align="center" style="{style.has_made_posdef_covar}">{sfmin.has_made_posdef_covar!r}</td>
-            </tr>
-            <tr>
-                <td align="center" title="Was last hesse call fail?">Hesse Fail</td>
-                <td align="center" title="Validity of covariance">HasCov</td>
-                <td align="center" title="Is EDM above goal EDM?">Above EDM</td>
-                <td align="center"></td>
-                <td align="center" title="Did last migrad call reach max call limit?">Reach calllim</td>
-            </tr>
-            <tr>
-                <td align="center" style="{style.hesse_failed}">{sfmin.hesse_failed!r}</td>
-                <td align="center" style="{style.has_covariance}">{sfmin.has_covariance!r}</td>
-                <td align="center" style="{style.is_above_max_edm}">{sfmin.is_above_max_edm!r}</td>
-                <td align="center"></td>
-                <td align="center" style="{style.has_reached_call_limit}">{sfmin.has_reached_call_limit!r}</td>
-            </tr>
-        </table>
-        """.format(**locals())
-        display_html(header + status, raw=True)
+        header = u"""<table>
+    <tr>
+        <td title="Minimum value of function">FCN = {sfmin.fval}</td>
+        <td title="Total number of call to FCN so far">TOTAL NCALL = {ncalls}</td>
+        <td title="Number of call in last migrad">NCALLS = {sfmin.nfcn}</td>
+    </tr>
+    <tr>
+        <td title="Estimated distance to minimum">EDM = {sfmin.edm}</td>
+        <td title="Maximum EDM definition of convergence">GOAL EDM = {goaledm}</td>
+        <td title="Error def. Amount of increase in FCN to be defined as 1 standard deviation">
+        UP = {sfmin.up}</td>
+    </tr>
+</table>\n""".format(**locals())
+        status = u"""<table>
+    <tr>
+        <td align="center" title="Validity of the migrad call">Valid</td>
+        <td align="center" title="Validity of parameters">Valid Param</td>
+        <td align="center" title="Is Covariance matrix accurate?">Accurate Covar</td>
+        <td align="center" title="Positive definiteness of covariance matrix">PosDef</td>
+        <td align="center" title="Was covariance matrix made posdef by adding diagonal element">Made PosDef</td>
+    </tr>
+    <tr>
+        <td align="center" style="{style.is_valid}">{sfmin.is_valid!r}</td>
+        <td align="center" style="{style.has_valid_parameters}">{sfmin.has_valid_parameters!r}</td>
+        <td align="center" style="{style.has_accurate_covar}">{sfmin.has_accurate_covar!r}</td>
+        <td align="center" style="{style.has_posdef_covar}">{sfmin.has_posdef_covar!r}</td>
+        <td align="center" style="{style.has_made_posdef_covar}">{sfmin.has_made_posdef_covar!r}</td>
+    </tr>
+    <tr>
+        <td align="center" title="Was last hesse call fail?">Hesse Fail</td>
+        <td align="center" title="Validity of covariance">HasCov</td>
+        <td align="center" title="Is EDM above goal EDM?">Above EDM</td>
+        <td align="center"></td>
+        <td align="center" title="Did last migrad call reach max call limit?">Reach calllim</td>
+    </tr>
+    <tr>
+        <td align="center" style="{style.hesse_failed}">{sfmin.hesse_failed!r}</td>
+        <td align="center" style="{style.has_covariance}">{sfmin.has_covariance!r}</td>
+        <td align="center" style="{style.is_above_max_edm}">{sfmin.is_above_max_edm!r}</td>
+        <td align="center"></td>
+        <td align="center" style="{style.has_reached_call_limit}">{sfmin.has_reached_call_limit!r}</td>
+    </tr>
+</table>""".format(**locals())
+        self.display(header + status)
 
-    @staticmethod
-    def print_merror(vname, smerr):
-        from IPython.core.display import display_html
+    def print_merror(self, vname, smerr):
         stat = 'VALID' if smerr.is_valid else 'PROBLEM'
         style = minos_style(smerr)
-        to_print = """
-        <span>Minos status for {vname}: <span style="{style.is_valid}">{stat}</span></span>
-        <table>
-            <tr>
-                <td title="lower and upper minos error of the parameter">Error</td>
-                <td>{smerr.lower}</td>
-                <td>{smerr.upper}</td>
-            </tr>
-            <tr>
-                <td title="Validity of minos error">Valid</td>
-                <td style="{style.lower_valid}">{smerr.lower_valid}</td>
-                <td style="{style.upper_valid}">{smerr.upper_valid}</td>
-            </tr>
-            <tr>
-                <td title="Did minos error search hit limit of any paramter?">At Limit</td>
-                <td style="{style.at_lower_limit}">{smerr.at_lower_limit}</td>
-                <td style="{style.at_upper_limit}">{smerr.at_upper_limit}</td>
-            </tr>
-            <tr>
-                <td title="I don't really know what this one means... Post it in issue if you know">Max FCN</td>
-                <td style="{style.at_lower_max_fcn}">{smerr.at_lower_max_fcn}</td>
-                <td style="{style.at_upper_max_fcn}">{smerr.at_upper_max_fcn}</td>
-            </tr>
-            <tr>
-                <td title="New minimum found when doing minos scan.">New Min</td>
-                <td style="{style.lower_new_min}">{smerr.lower_new_min}</td>
-                <td style="{style.upper_new_min}">{smerr.upper_new_min}</td>
-            </tr>
-        </table>
-        """.format(**locals())
-        display_html(to_print, raw=True)
+        to_print = """<span>Minos status for {vname}: <span style="{style.is_valid}">{stat}</span></span>
+<table>
+    <tr>
+        <td title="lower and upper minos error of the parameter">Error</td>
+        <td>{smerr.lower}</td>
+        <td>{smerr.upper}</td>
+    </tr>
+    <tr>
+        <td title="Validity of minos error">Valid</td>
+        <td style="{style.lower_valid}">{smerr.lower_valid}</td>
+        <td style="{style.upper_valid}">{smerr.upper_valid}</td>
+    </tr>
+    <tr>
+        <td title="Did minos error search hit limit of any parameter?">At Limit</td>
+        <td style="{style.at_lower_limit}">{smerr.at_lower_limit}</td>
+        <td style="{style.at_upper_limit}">{smerr.at_upper_limit}</td>
+    </tr>
+    <tr>
+        <td title="I don't really know what this one means... Post it in issue if you know">Max FCN</td>
+        <td style="{style.at_lower_max_fcn}">{smerr.at_lower_max_fcn}</td>
+        <td style="{style.at_upper_max_fcn}">{smerr.at_upper_max_fcn}</td>
+    </tr>
+    <tr>
+        <td title="New minimum found when doing minos scan.">New Min</td>
+        <td style="{style.lower_new_min}">{smerr.lower_new_min}</td>
+        <td style="{style.upper_new_min}">{smerr.upper_new_min}</td>
+    </tr>
+</table>""".format(**locals())
+        self.display(to_print)
 
     def print_param(self, mps, merr=None, float_format='%5.3e',
                     smart_latex=True, latex_map=None):
-        from IPython.core.display import display_html
         """print list of parameters
         Arguments:
 
@@ -168,21 +166,19 @@ class HtmlFrontend:
                 symbol. default True
         """
         to_print = ""
-        uid = randid()
-        header = """
-        <table>
-            <tr>
-                <td><a href="#" onclick="$('#{uid}').toggle()">+</a></td>
-                <td title="Variable name">Name</td>
-                <td title="Value of parameter">Value</td>
-                <td title="Parabolic error">Parab Error</td>
-                <td title="Minos lower error">Minos Error-</td>
-                <td title="Minos upper error">Minos Error+</td>
-                <td title="Lower limit of the parameter">Limit-</td>
-                <td title="Upper limit of the parameter">Limit+</td>
-                <td title="Is the parameter fixed in the fit">FIXED</td>
-            </tr>
-        """.format(**locals())
+        uid = randid(self.rng)
+        header = """<table>
+    <tr>
+        <td><a href="#" onclick="$('#{uid}').toggle()">+</a></td>
+        <td title="Variable name">Name</td>
+        <td title="Value of parameter">Value</td>
+        <td title="Parabolic error">Parab Error</td>
+        <td title="Minos lower error">Minos Error-</td>
+        <td title="Minos upper error">Minos Error+</td>
+        <td title="Lower limit of the parameter">Limit-</td>
+        <td title="Upper limit of the parameter">Limit+</td>
+        <td title="Is the parameter fixed in the fit">FIXED</td>
+    </tr>\n""".format(**locals())
         to_print += header
         for i, mp in enumerate(mps):
             minos_p, minos_m = (0., 0.) if merr is None or mp.name not in merr else \
@@ -191,93 +187,72 @@ class HtmlFrontend:
             limit_m = '' if not mp.has_lower_limit else mp.lower_limit
             fixed = 'FIXED' if mp.is_fixed else ''
             j = i + 1
-            content = """
-            <tr>
-                <td>{j}</td>
-                <td>{mp.name}</td>
-                <td>{mp.value:g}</td>
-                <td>{mp.error:g}</td>
-                <td>{minos_m:g}</td>
-                <td>{minos_p:g}</td>
-                <td>{limit_m!s}</td>
-                <td>{limit_p!s}</td>
-                <td>{fixed}</td>
-            </tr>
-            """.format(**locals())
+            content = """    <tr>
+        <td>{j}</td>
+        <td>{mp.name}</td>
+        <td>{mp.value:g}</td>
+        <td>{mp.error:g}</td>
+        <td>{minos_m:g}</td>
+        <td>{minos_p:g}</td>
+        <td>{limit_m!s}</td>
+        <td>{limit_p!s}</td>
+        <td>{fixed}</td>
+    </tr>\n""".format(**locals())
             to_print += content
-        to_print += """
-            </table>
-        """
+        to_print += "</table>\n"
         ltable = LatexFactory.build_param_table(mps, merr,
                                                 float_format=float_format, smart_latex=smart_latex,
                                                 latex_map=latex_map)
 
         # rows = str(ltable).count('\n')+1
         to_print += self.hidden_table(str(ltable), uid)
-        display_html(to_print, raw=True)
+        self.display(to_print)
 
     def print_banner(self, cmd):
-        # display_html('<h2>%s</h2>'%cmd, raw=True)
+        # display('<h2>%s</h2>'%cmd, raw=True)
         pass
 
-    @staticmethod
-    def toggle_sign(uid):
+    def toggle_sign(self, uid):
         return """<a onclick="$('#%s').toggle()" href="#">+</a>""" % uid
 
-    @staticmethod
-    def hidden_table(s, uid):
+    def hidden_table(self, s, uid):
         rows = s.count('\n') + 2
-        ret = r"""
-            <pre id="%s" style="display:none;">
-            <textarea rows="%d" cols="50" onclick="this.select()" readonly>%s</textarea>
-            </pre>
-            """ % (uid, rows, s)
+        ret = r"""<pre id="%s" style="display:none;">
+<textarea rows="%d" cols="50" onclick="this.select()" readonly>
+%s
+</textarea>
+</pre>""" % (uid, rows, s)
         return ret
 
     def print_matrix(self, vnames, matrix, latex_map=None):
-        from IPython.core.display import display_html
-        latexuid = randid()
+        latexuid = randid(self.rng)
         latextable = LatexFactory.build_matrix(vnames, matrix,
                                                latex_map=latex_map)
-        to_print = """
-            <table>
-                <tr>
-                    <td>%s</td>
-        """ % self.toggle_sign(latexuid)
+        to_print = """<table>
+    <tr>
+        <td>%s</td>""" % self.toggle_sign(latexuid)
         for v in vnames:
-            to_print += """
-            <td>
+            to_print += """        <td>
             <div style="width:20px;position:relative; width: -moz-fit-content;">
             <div style="display:inline-block;-webkit-writing-mode:vertical-rl;-moz-writing-mode: vertical-rl;writing-mode: vertical-rl;">
             {v}
             </div>
             </div>
-            </td>
-            """.format(**locals())
-        to_print += """
-                </tr>
-                """
+        </td>""".format(**locals())
+        to_print += "    </tr>"
         for i, v1 in enumerate(vnames):
-            to_print += """
-            <tr>
-                <td>{v1}</td>
-            """.format(**locals())
+            to_print += """    <tr>
+        <td>{v1}</td>""".format(**locals())
             for j, v2 in enumerate(vnames):
                 val = matrix[i][j]
                 color = Gradient.rgb_color_for(val)
-                to_print += """
-                <td style="background-color:{color}">
-                {val:3.2f}
-                </td>
-                """.format(**locals())
-            to_print += """
-            </tr>
-            """
+                to_print += """        <td style="background-color:{color}">
+            {val:3.2f}
+        </td>""".format(**locals())
+            to_print += """    </tr>"""
         to_print += '</table>\n'
         to_print += self.hidden_table(str(latextable), latexuid)
-        display_html(to_print, raw=True)
+        self.display(to_print)
 
-    @staticmethod
-    def print_hline():
-        from IPython.core.display import display_html
-        display_html('<hr>', raw=True)
+    def print_hline(self, width=None):
+        self.display('<hr>')

--- a/iminuit/py23_compat.py
+++ b/iminuit/py23_compat.py
@@ -15,3 +15,12 @@ def is_string(s):
         return isinstance(s, basestring)
     except NameError:  # Python 3
         return isinstance(s, str)
+
+try:
+    from abc import ABC
+except ImportError:
+    from abc import ABCMeta
+
+    class ABC(object):
+        __metaclass__ = ABCMeta
+        pass

--- a/iminuit/tests/test_frontend.py
+++ b/iminuit/tests/test_frontend.py
@@ -1,4 +1,11 @@
 from __future__ import (absolute_import, division, print_function)
+# Here we don't import unicode_literals, because otherwise we cannot write
+# in "\usepackage" and similar in the string literals below.
+# The problem is an inconsistency regarding the effect of
+# from __future__ import unicode_literals in Python 2 and 3, which is
+# explained here:
+# https://stackoverflow.com/questions/7602171/unicode-error-unicodeescape-codec-cant-decode-bytes-string-with-u
+# We want the same code to work in Python 2 and 3 and chose this solution.
 import sys
 from iminuit import Minuit
 import iminuit.frontends.html as html

--- a/iminuit/tests/test_frontend.py
+++ b/iminuit/tests/test_frontend.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 import sys
 from iminuit import Minuit
 import iminuit.frontends.html as html
@@ -16,18 +15,22 @@ def f1(x, y):
 def test_html(capsys):
     def out(): return capsys.readouterr()[0]
 
+    class FakeRandom(object):
+        def choice(self, s):
+            return s[0]
+
     class Frontend(html.HtmlFrontend):
-        rng = random.Random(x=1) # fix random seed for reproducability
-        def display(self, *args):
+        rng = FakeRandom() # for reproducability
+        def display(self, *args): # text to stdout
             sys.stdout.write('\n'.join(args)+'\n')
 
     m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1, frontend=Frontend())
     m.tol = 1e-4
 
     m.print_initial_param()
-    assert """<table>
+    assert r"""<table>
     <tr>
-        <td><a href="#" onclick="$('#gSNnzxHPeb').toggle()">+</a></td>
+        <td><a href="#" onclick="$('#aaaaaaaaaa').toggle()">+</a></td>
         <td title="Variable name">Name</td>
         <td title="Value of parameter">Value</td>
         <td title="Parabolic error">Parab Error</td>
@@ -60,17 +63,17 @@ def test_html(capsys):
         <td></td>
     </tr>
 </table>
-<pre id="gSNnzxHPeb" style="display:none;">
+<pre id="aaaaaaaaaa" style="display:none;">
 <textarea rows="10" cols="50" onclick="this.select()" readonly>
-\\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
-\\hline
- & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\\\
-\\hline
-1 & x & 0.000e+00 & 1.000e+00 &  &  &  &  & \\\\
-\\hline
-2 & y & 0.000e+00 & 1.000e+00 &  &  &  &  & \\\\
-\\hline
-\\end{tabular}
+\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
+\hline
+ & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\
+\hline
+1 & x & 0.000e+00 & 1.000e+00 &  &  &  &  & \\
+\hline
+2 & y & 0.000e+00 & 1.000e+00 &  &  &  &  & \\
+\hline
+\end{tabular}
 </textarea>
 </pre>
 """ == out()
@@ -78,7 +81,7 @@ def test_html(capsys):
     m.migrad()
     fmin = m.get_fmin()
 
-    assert """<hr>
+    assert r"""<hr>
 <table>
     <tr>
         <td title="Minimum value of function">FCN = 1.0</td>
@@ -124,7 +127,7 @@ def test_html(capsys):
 </table>
 <table>
     <tr>
-        <td><a href="#" onclick="$('#RwNaxLlXUb').toggle()">+</a></td>
+        <td><a href="#" onclick="$('#aaaaaaaaaa').toggle()">+</a></td>
         <td title="Variable name">Name</td>
         <td title="Value of parameter">Value</td>
         <td title="Parabolic error">Parab Error</td>
@@ -157,24 +160,24 @@ def test_html(capsys):
         <td></td>
     </tr>
 </table>
-<pre id="RwNaxLlXUb" style="display:none;">
+<pre id="aaaaaaaaaa" style="display:none;">
 <textarea rows="10" cols="50" onclick="this.select()" readonly>
-\\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
-\\hline
- & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\\\
-\\hline
-1 & x & 2.000e+00 & 1.000e+00 &  &  &  &  & \\\\
-\\hline
-2 & y & 1.000e+00 & 5.000e-01 &  &  &  &  & \\\\
-\\hline
-\\end{tabular}
+\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
+\hline
+ & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\
+\hline
+1 & x & 2.000e+00 & 1.000e+00 &  &  &  &  & \\
+\hline
+2 & y & 1.000e+00 & 5.000e-01 &  &  &  &  & \\
+\hline
+\end{tabular}
 </textarea>
 </pre>
 <hr>
 """ % fmin.edm == out()
 
     m.minos()
-    assert """<span>Minos status for x: <span style="background-color:#92CCA6">VALID</span></span>
+    assert r"""<span>Minos status for x: <span style="background-color:#92CCA6">VALID</span></span>
 <table>
     <tr>
         <td title="lower and upper minos error of the parameter">Error</td>
@@ -234,9 +237,9 @@ def test_html(capsys):
        m.merrors[('y', -1.0)], m.merrors[('y', 1.0)]) == out()
 
     m.print_matrix()
-    assert """<table>
+    assert r"""<table>
     <tr>
-        <td><a onclick="$('#bCWtlvblwz').toggle()" href="#">+</a></td>        <td>
+        <td><a onclick="$('#aaaaaaaaaa').toggle()" href="#">+</a></td>        <td>
             <div style="width:20px;position:relative; width: -moz-fit-content;">
             <div style="display:inline-block;-webkit-writing-mode:vertical-rl;-moz-writing-mode: vertical-rl;writing-mode: vertical-rl;">
             x
@@ -259,26 +262,26 @@ def test_html(capsys):
         </td>        <td style="background-color:rgb(255,117,117)">
             1.00
         </td>    </tr></table>
-<pre id="bCWtlvblwz" style="display:none;">
+<pre id="aaaaaaaaaa" style="display:none;">
 <textarea rows="13" cols="50" onclick="this.select()" readonly>
-%\\usepackage[table]{xcolor} % include this for color
-%\\usepackage{rotating} % include this for rotate header
-%\\documentclass[xcolor=table]{beamer} % for beamer
-\\begin{tabular}{|c|c|c|}
-\\hline
-\\rotatebox{90}{} & \\rotatebox{90}{x} & \\rotatebox{90}{y}\\\\
-\\hline
-x & \\cellcolor[RGB]{255,117,117} 1.00 & \\cellcolor[RGB]{163,254,186} 0.00\\\\
-\\hline
-y & \\cellcolor[RGB]{163,254,186} 0.00 & \\cellcolor[RGB]{255,117,117} 1.00\\\\
-\\hline
-\\end{tabular}
+%\usepackage[table]{xcolor} % include this for color
+%\usepackage{rotating} % include this for rotate header
+%\documentclass[xcolor=table]{beamer} % for beamer
+\begin{tabular}{|c|c|c|}
+\hline
+\rotatebox{90}{} & \rotatebox{90}{x} & \rotatebox{90}{y}\\
+\hline
+x & \cellcolor[RGB]{255,117,117} 1.00 & \cellcolor[RGB]{163,254,186} 0.00\\
+\hline
+y & \cellcolor[RGB]{163,254,186} 0.00 & \cellcolor[RGB]{255,117,117} 1.00\\
+\hline
+\end{tabular}
 </textarea>
 </pre>
 """ == out()
 
     m.print_fmin()
-    assert """<hr>
+    assert r"""<hr>
 <table>
     <tr>
         <td title="Minimum value of function">FCN = 1.0</td>
@@ -324,7 +327,7 @@ y & \\cellcolor[RGB]{163,254,186} 0.00 & \\cellcolor[RGB]{255,117,117} 1.00\\\\
 </table>
 <table>
     <tr>
-        <td><a href="#" onclick="$('#mmlxpbRCHj').toggle()">+</a></td>
+        <td><a href="#" onclick="$('#aaaaaaaaaa').toggle()">+</a></td>
         <td title="Variable name">Name</td>
         <td title="Value of parameter">Value</td>
         <td title="Parabolic error">Parab Error</td>
@@ -357,24 +360,24 @@ y & \\cellcolor[RGB]{163,254,186} 0.00 & \\cellcolor[RGB]{255,117,117} 1.00\\\\
         <td></td>
     </tr>
 </table>
-<pre id="mmlxpbRCHj" style="display:none;">
+<pre id="aaaaaaaaaa" style="display:none;">
 <textarea rows="10" cols="50" onclick="this.select()" readonly>
-\\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
-\\hline
- & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\\\
-\\hline
-1 & x & 2.000e+00 & 1.000e+00 & -1.000e+00 & 1.000e+00 &  &  & \\\\
-\\hline
-2 & y & 1.000e+00 & 5.000e-01 & -5.000e-01 & 5.000e-01 &  &  & \\\\
-\\hline
-\\end{tabular}
+\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
+\hline
+ & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\
+\hline
+1 & x & 2.000e+00 & 1.000e+00 & -1.000e+00 & 1.000e+00 &  &  & \\
+\hline
+2 & y & 1.000e+00 & 5.000e-01 & -5.000e-01 & 5.000e-01 &  &  & \\
+\hline
+\end{tabular}
 </textarea>
 </pre>
 <hr>
 """ % (m.get_fmin().edm) == out()
 
     m.print_all_minos()
-    assert """<span>Minos status for x: <span style="background-color:#92CCA6">VALID</span></span>
+    assert r"""<span>Minos status for x: <span style="background-color:#92CCA6">VALID</span></span>
 <table>
     <tr>
         <td title="lower and upper minos error of the parameter">Error</td>
@@ -441,7 +444,7 @@ def test_console(capsys):
     m.tol = 1e-4
 
     m.print_initial_param()
-    assert """----------------------------------------------------------------------------------------
+    assert r"""----------------------------------------------------------------------------------------
 | No | Name |  Value   | Para Err |   Err-   |   Err+   | Limit-   | Limit+   | Fixed? |
 ----------------------------------------------------------------------------------------
 |  0 |    x | 0        | 1        |          |          |          |          |   No   |
@@ -450,7 +453,7 @@ def test_console(capsys):
 """ == out()
 
     m.migrad()
-    assert """**************************************************
+    assert r"""**************************************************
 *                     MIGRAD                     *
 **************************************************
 
@@ -465,7 +468,7 @@ edm = %s (Goal: 1e-08) | up = 1.0
 --------------------------------------------------------------------------------------
 |     Hesse Fail |        Has Cov |      Above EDM |                |  Reach calllim |
 --------------------------------------------------------------------------------------
-|          False |           True |          False |            u'' |          False |
+|          False |           True |          False |                |          False |
 --------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------
 | No | Name |  Value   | Para Err |   Err-   |   Err+   | Limit-   | Limit+   | Fixed? |
@@ -477,7 +480,7 @@ edm = %s (Goal: 1e-08) | up = 1.0
 """ % m.get_fmin().edm == out()
 
     m.minos()
-    assert """**************************************************
+    assert r"""**************************************************
 *                     MINOS                      *
 **************************************************
 
@@ -502,7 +505,7 @@ Minos Status for y: VALID
 """ == out()
 
     m.print_matrix()
-    assert """-------------------
+    assert r"""-------------------
 Correlation
 -------------------
        |    0    1 
@@ -513,7 +516,7 @@ y    1 | 0.00 1.00
 """ == out()
 
     m.print_fmin()
-    assert """**************************************************************************************
+    assert r"""**************************************************************************************
 --------------------------------------------------------------------------------------
 fval = 1.0 | total call = 48 | ncalls = 24
 edm = %s (Goal: 1e-08) | up = 1.0
@@ -524,7 +527,7 @@ edm = %s (Goal: 1e-08) | up = 1.0
 --------------------------------------------------------------------------------------
 |     Hesse Fail |        Has Cov |      Above EDM |                |  Reach calllim |
 --------------------------------------------------------------------------------------
-|          False |           True |          False |            u'' |          False |
+|          False |           True |          False |                |          False |
 --------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------
 | No | Name |  Value   | Para Err |   Err-   |   Err+   | Limit-   | Limit+   | Fixed? |
@@ -536,7 +539,7 @@ edm = %s (Goal: 1e-08) | up = 1.0
 """ % (m.get_fmin().edm) == out()
 
     m.print_all_minos()
-    assert """-------------------------------------------------
+    assert r"""-------------------------------------------------
 Minos Status for x: VALID
 -------------------------------------------------
 |      Error      |      -1      |      1       |

--- a/iminuit/tests/test_frontend.py
+++ b/iminuit/tests/test_frontend.py
@@ -1,35 +1,557 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import sys
 from iminuit import Minuit
-from iminuit.frontends.html import HtmlFrontend
-from iminuit.frontends.console import ConsoleFrontend
+import iminuit.frontends.html as html
+import iminuit.frontends.console as console
 from iminuit.tests.utils import requires_dependency
+import random
 
 
 def f1(x, y):
-    return (1 - x) ** 2 + 100 * (y - 1) ** 2
+    return (x - 2) ** 2 + (y - 1) ** 2 / 0.25 + 1
 
 
 @requires_dependency('IPython')
-def test_html():
-    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1, frontend=HtmlFrontend())
+def test_html(capsys):
+    def out(): return capsys.readouterr()[0]
+
+    class Frontend(html.HtmlFrontend):
+        rng = random.Random(x=1) # fix random seed for reproducability
+        def display(self, *args):
+            sys.stdout.write('\n'.join(args)+'\n')
+
+    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1, frontend=Frontend())
     m.tol = 1e-4
-    m.migrad()
-    m.minos()
-    m.print_matrix()
+
     m.print_initial_param()
+    assert """<table>
+    <tr>
+        <td><a href="#" onclick="$('#gSNnzxHPeb').toggle()">+</a></td>
+        <td title="Variable name">Name</td>
+        <td title="Value of parameter">Value</td>
+        <td title="Parabolic error">Parab Error</td>
+        <td title="Minos lower error">Minos Error-</td>
+        <td title="Minos upper error">Minos Error+</td>
+        <td title="Lower limit of the parameter">Limit-</td>
+        <td title="Upper limit of the parameter">Limit+</td>
+        <td title="Is the parameter fixed in the fit">FIXED</td>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>x</td>
+        <td>0</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>y</td>
+        <td>0</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>
+<pre id="gSNnzxHPeb" style="display:none;">
+<textarea rows="10" cols="50" onclick="this.select()" readonly>
+\\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
+\\hline
+ & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\\\
+\\hline
+1 & x & 0.000e+00 & 1.000e+00 &  &  &  &  & \\\\
+\\hline
+2 & y & 0.000e+00 & 1.000e+00 &  &  &  &  & \\\\
+\\hline
+\\end{tabular}
+</textarea>
+</pre>
+""" == out()
+
+    m.migrad()
+    fmin = m.get_fmin()
+
+    assert """<hr>
+<table>
+    <tr>
+        <td title="Minimum value of function">FCN = 1.0</td>
+        <td title="Total number of call to FCN so far">TOTAL NCALL = 24</td>
+        <td title="Number of call in last migrad">NCALLS = 24</td>
+    </tr>
+    <tr>
+        <td title="Estimated distance to minimum">EDM = %s</td>
+        <td title="Maximum EDM definition of convergence">GOAL EDM = 1e-08</td>
+        <td title="Error def. Amount of increase in FCN to be defined as 1 standard deviation">
+        UP = 1.0</td>
+    </tr>
+</table>
+<table>
+    <tr>
+        <td align="center" title="Validity of the migrad call">Valid</td>
+        <td align="center" title="Validity of parameters">Valid Param</td>
+        <td align="center" title="Is Covariance matrix accurate?">Accurate Covar</td>
+        <td align="center" title="Positive definiteness of covariance matrix">PosDef</td>
+        <td align="center" title="Was covariance matrix made posdef by adding diagonal element">Made PosDef</td>
+    </tr>
+    <tr>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td align="center" title="Was last hesse call fail?">Hesse Fail</td>
+        <td align="center" title="Validity of covariance">HasCov</td>
+        <td align="center" title="Is EDM above goal EDM?">Above EDM</td>
+        <td align="center"></td>
+        <td align="center" title="Did last migrad call reach max call limit?">Reach calllim</td>
+    </tr>
+    <tr>
+        <td align="center" style="background-color:#92CCA6">False</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">False</td>
+        <td align="center"></td>
+        <td align="center" style="background-color:#92CCA6">False</td>
+    </tr>
+</table>
+<table>
+    <tr>
+        <td><a href="#" onclick="$('#RwNaxLlXUb').toggle()">+</a></td>
+        <td title="Variable name">Name</td>
+        <td title="Value of parameter">Value</td>
+        <td title="Parabolic error">Parab Error</td>
+        <td title="Minos lower error">Minos Error-</td>
+        <td title="Minos upper error">Minos Error+</td>
+        <td title="Lower limit of the parameter">Limit-</td>
+        <td title="Upper limit of the parameter">Limit+</td>
+        <td title="Is the parameter fixed in the fit">FIXED</td>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>x</td>
+        <td>2</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>y</td>
+        <td>1</td>
+        <td>0.5</td>
+        <td>0</td>
+        <td>0</td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>
+<pre id="RwNaxLlXUb" style="display:none;">
+<textarea rows="10" cols="50" onclick="this.select()" readonly>
+\\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
+\\hline
+ & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\\\
+\\hline
+1 & x & 2.000e+00 & 1.000e+00 &  &  &  &  & \\\\
+\\hline
+2 & y & 1.000e+00 & 5.000e-01 &  &  &  &  & \\\\
+\\hline
+\\end{tabular}
+</textarea>
+</pre>
+<hr>
+""" % fmin.edm == out()
+
+    m.minos()
+    assert """<span>Minos status for x: <span style="background-color:#92CCA6">VALID</span></span>
+<table>
+    <tr>
+        <td title="lower and upper minos error of the parameter">Error</td>
+        <td>%s</td>
+        <td>%s</td>
+    </tr>
+    <tr>
+        <td title="Validity of minos error">Valid</td>
+        <td style="background-color:#92CCA6">True</td>
+        <td style="background-color:#92CCA6">True</td>
+    </tr>
+    <tr>
+        <td title="Did minos error search hit limit of any parameter?">At Limit</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="I don't really know what this one means... Post it in issue if you know">Max FCN</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="New minimum found when doing minos scan.">New Min</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+</table>
+<span>Minos status for y: <span style="background-color:#92CCA6">VALID</span></span>
+<table>
+    <tr>
+        <td title="lower and upper minos error of the parameter">Error</td>
+        <td>%s</td>
+        <td>%s</td>
+    </tr>
+    <tr>
+        <td title="Validity of minos error">Valid</td>
+        <td style="background-color:#92CCA6">True</td>
+        <td style="background-color:#92CCA6">True</td>
+    </tr>
+    <tr>
+        <td title="Did minos error search hit limit of any parameter?">At Limit</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="I don't really know what this one means... Post it in issue if you know">Max FCN</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="New minimum found when doing minos scan.">New Min</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+</table>
+""" % (m.merrors[('x', -1.0)], m.merrors[('x', 1.0)],
+       m.merrors[('y', -1.0)], m.merrors[('y', 1.0)]) == out()
+
+    m.print_matrix()
+    assert """<table>
+    <tr>
+        <td><a onclick="$('#bCWtlvblwz').toggle()" href="#">+</a></td>        <td>
+            <div style="width:20px;position:relative; width: -moz-fit-content;">
+            <div style="display:inline-block;-webkit-writing-mode:vertical-rl;-moz-writing-mode: vertical-rl;writing-mode: vertical-rl;">
+            x
+            </div>
+            </div>
+        </td>        <td>
+            <div style="width:20px;position:relative; width: -moz-fit-content;">
+            <div style="display:inline-block;-webkit-writing-mode:vertical-rl;-moz-writing-mode: vertical-rl;writing-mode: vertical-rl;">
+            y
+            </div>
+            </div>
+        </td>    </tr>    <tr>
+        <td>x</td>        <td style="background-color:rgb(255,117,117)">
+            1.00
+        </td>        <td style="background-color:rgb(163,254,186)">
+            0.00
+        </td>    </tr>    <tr>
+        <td>y</td>        <td style="background-color:rgb(163,254,186)">
+            0.00
+        </td>        <td style="background-color:rgb(255,117,117)">
+            1.00
+        </td>    </tr></table>
+<pre id="bCWtlvblwz" style="display:none;">
+<textarea rows="13" cols="50" onclick="this.select()" readonly>
+%\\usepackage[table]{xcolor} % include this for color
+%\\usepackage{rotating} % include this for rotate header
+%\\documentclass[xcolor=table]{beamer} % for beamer
+\\begin{tabular}{|c|c|c|}
+\\hline
+\\rotatebox{90}{} & \\rotatebox{90}{x} & \\rotatebox{90}{y}\\\\
+\\hline
+x & \\cellcolor[RGB]{255,117,117} 1.00 & \\cellcolor[RGB]{163,254,186} 0.00\\\\
+\\hline
+y & \\cellcolor[RGB]{163,254,186} 0.00 & \\cellcolor[RGB]{255,117,117} 1.00\\\\
+\\hline
+\\end{tabular}
+</textarea>
+</pre>
+""" == out()
+
     m.print_fmin()
+    assert """<hr>
+<table>
+    <tr>
+        <td title="Minimum value of function">FCN = 1.0</td>
+        <td title="Total number of call to FCN so far">TOTAL NCALL = 48</td>
+        <td title="Number of call in last migrad">NCALLS = 24</td>
+    </tr>
+    <tr>
+        <td title="Estimated distance to minimum">EDM = %s</td>
+        <td title="Maximum EDM definition of convergence">GOAL EDM = 1e-08</td>
+        <td title="Error def. Amount of increase in FCN to be defined as 1 standard deviation">
+        UP = 1.0</td>
+    </tr>
+</table>
+<table>
+    <tr>
+        <td align="center" title="Validity of the migrad call">Valid</td>
+        <td align="center" title="Validity of parameters">Valid Param</td>
+        <td align="center" title="Is Covariance matrix accurate?">Accurate Covar</td>
+        <td align="center" title="Positive definiteness of covariance matrix">PosDef</td>
+        <td align="center" title="Was covariance matrix made posdef by adding diagonal element">Made PosDef</td>
+    </tr>
+    <tr>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td align="center" title="Was last hesse call fail?">Hesse Fail</td>
+        <td align="center" title="Validity of covariance">HasCov</td>
+        <td align="center" title="Is EDM above goal EDM?">Above EDM</td>
+        <td align="center"></td>
+        <td align="center" title="Did last migrad call reach max call limit?">Reach calllim</td>
+    </tr>
+    <tr>
+        <td align="center" style="background-color:#92CCA6">False</td>
+        <td align="center" style="background-color:#92CCA6">True</td>
+        <td align="center" style="background-color:#92CCA6">False</td>
+        <td align="center"></td>
+        <td align="center" style="background-color:#92CCA6">False</td>
+    </tr>
+</table>
+<table>
+    <tr>
+        <td><a href="#" onclick="$('#mmlxpbRCHj').toggle()">+</a></td>
+        <td title="Variable name">Name</td>
+        <td title="Value of parameter">Value</td>
+        <td title="Parabolic error">Parab Error</td>
+        <td title="Minos lower error">Minos Error-</td>
+        <td title="Minos upper error">Minos Error+</td>
+        <td title="Lower limit of the parameter">Limit-</td>
+        <td title="Upper limit of the parameter">Limit+</td>
+        <td title="Is the parameter fixed in the fit">FIXED</td>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>x</td>
+        <td>2</td>
+        <td>1</td>
+        <td>-1</td>
+        <td>1</td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>y</td>
+        <td>1</td>
+        <td>0.5</td>
+        <td>-0.5</td>
+        <td>0.5</td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>
+<pre id="mmlxpbRCHj" style="display:none;">
+<textarea rows="10" cols="50" onclick="this.select()" readonly>
+\\begin{tabular}{|c|r|r|r|r|r|r|r|c|}
+\\hline
+ & Name & Value & Para Error & Error+ & Error- & Limit+ & Limit- & FIXED\\\\
+\\hline
+1 & x & 2.000e+00 & 1.000e+00 & -1.000e+00 & 1.000e+00 &  &  & \\\\
+\\hline
+2 & y & 1.000e+00 & 5.000e-01 & -5.000e-01 & 5.000e-01 &  &  & \\\\
+\\hline
+\\end{tabular}
+</textarea>
+</pre>
+<hr>
+""" % (m.get_fmin().edm) == out()
+
     m.print_all_minos()
-    m.latex_matrix()
+    assert """<span>Minos status for x: <span style="background-color:#92CCA6">VALID</span></span>
+<table>
+    <tr>
+        <td title="lower and upper minos error of the parameter">Error</td>
+        <td>%s</td>
+        <td>%s</td>
+    </tr>
+    <tr>
+        <td title="Validity of minos error">Valid</td>
+        <td style="background-color:#92CCA6">True</td>
+        <td style="background-color:#92CCA6">True</td>
+    </tr>
+    <tr>
+        <td title="Did minos error search hit limit of any parameter?">At Limit</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="I don't really know what this one means... Post it in issue if you know">Max FCN</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="New minimum found when doing minos scan.">New Min</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+</table>
+<span>Minos status for y: <span style="background-color:#92CCA6">VALID</span></span>
+<table>
+    <tr>
+        <td title="lower and upper minos error of the parameter">Error</td>
+        <td>%s</td>
+        <td>%s</td>
+    </tr>
+    <tr>
+        <td title="Validity of minos error">Valid</td>
+        <td style="background-color:#92CCA6">True</td>
+        <td style="background-color:#92CCA6">True</td>
+    </tr>
+    <tr>
+        <td title="Did minos error search hit limit of any parameter?">At Limit</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="I don't really know what this one means... Post it in issue if you know">Max FCN</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+    <tr>
+        <td title="New minimum found when doing minos scan.">New Min</td>
+        <td style="background-color:#92CCA6">False</td>
+        <td style="background-color:#92CCA6">False</td>
+    </tr>
+</table>
+""" % (m.merrors[('x', -1.0)], m.merrors[('x', 1.0)],
+       m.merrors[('y', -1.0)], m.merrors[('y', 1.0)]) == out()
 
 
-def test_console():
-    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1, frontend=ConsoleFrontend())
+def test_console(capsys):
+    def out(): return capsys.readouterr()[0]
+
+    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=1, frontend=console.ConsoleFrontend())
     m.tol = 1e-4
-    m.migrad()
-    m.minos()
-    m.print_matrix()
+
     m.print_initial_param()
+    assert """----------------------------------------------------------------------------------------
+| No | Name |  Value   | Para Err |   Err-   |   Err+   | Limit-   | Limit+   | Fixed? |
+----------------------------------------------------------------------------------------
+|  0 |    x | 0        | 1        |          |          |          |          |   No   |
+|  1 |    y | 0        | 1        |          |          |          |          |   No   |
+----------------------------------------------------------------------------------------
+""" == out()
+
+    m.migrad()
+    assert """**************************************************
+*                     MIGRAD                     *
+**************************************************
+
+**************************************************************************************
+--------------------------------------------------------------------------------------
+fval = 1.0 | total call = 24 | ncalls = 24
+edm = %s (Goal: 1e-08) | up = 1.0
+--------------------------------------------------------------------------------------
+|          Valid |    Valid Param | Accurate Covar |         Posdef |    Made Posdef |
+--------------------------------------------------------------------------------------
+|           True |           True |           True |           True |          False |
+--------------------------------------------------------------------------------------
+|     Hesse Fail |        Has Cov |      Above EDM |                |  Reach calllim |
+--------------------------------------------------------------------------------------
+|          False |           True |          False |            u'' |          False |
+--------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------
+| No | Name |  Value   | Para Err |   Err-   |   Err+   | Limit-   | Limit+   | Fixed? |
+----------------------------------------------------------------------------------------
+|  0 |    x | 2        | 1        |          |          |          |          |   No   |
+|  1 |    y | 1        | 0.5      |          |          |          |          |   No   |
+----------------------------------------------------------------------------------------
+**************************************************************************************
+""" % m.get_fmin().edm == out()
+
+    m.minos()
+    assert """**************************************************
+*                     MINOS                      *
+**************************************************
+
+-------------------------------------------------
+Minos Status for x: VALID
+-------------------------------------------------
+|      Error      |      -1      |      1       |
+|      Valid      |     True     |     True     |
+|    At Limit     |    False     |    False     |
+|     Max FCN     |    False     |    False     |
+|     New Min     |    False     |    False     |
+-------------------------------------------------
+-------------------------------------------------
+Minos Status for y: VALID
+-------------------------------------------------
+|      Error      |     -0.5     |     0.5      |
+|      Valid      |     True     |     True     |
+|    At Limit     |    False     |    False     |
+|     Max FCN     |    False     |    False     |
+|     New Min     |    False     |    False     |
+-------------------------------------------------
+""" == out()
+
+    m.print_matrix()
+    assert """-------------------
+Correlation
+-------------------
+       |    0    1 
+-------------------
+x    0 | 1.00 0.00 
+y    1 | 0.00 1.00 
+-------------------
+""" == out()
+
     m.print_fmin()
+    assert """**************************************************************************************
+--------------------------------------------------------------------------------------
+fval = 1.0 | total call = 48 | ncalls = 24
+edm = %s (Goal: 1e-08) | up = 1.0
+--------------------------------------------------------------------------------------
+|          Valid |    Valid Param | Accurate Covar |         Posdef |    Made Posdef |
+--------------------------------------------------------------------------------------
+|           True |           True |           True |           True |          False |
+--------------------------------------------------------------------------------------
+|     Hesse Fail |        Has Cov |      Above EDM |                |  Reach calllim |
+--------------------------------------------------------------------------------------
+|          False |           True |          False |            u'' |          False |
+--------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------
+| No | Name |  Value   | Para Err |   Err-   |   Err+   | Limit-   | Limit+   | Fixed? |
+----------------------------------------------------------------------------------------
+|  0 |    x | 2        | 1        | -1       | 1        |          |          |   No   |
+|  1 |    y | 1        | 0.5      | -0.5     | 0.5      |          |          |   No   |
+----------------------------------------------------------------------------------------
+**************************************************************************************
+""" % (m.get_fmin().edm) == out()
+
     m.print_all_minos()
-    m.latex_matrix()
+    assert """-------------------------------------------------
+Minos Status for x: VALID
+-------------------------------------------------
+|      Error      |      -1      |      1       |
+|      Valid      |     True     |     True     |
+|    At Limit     |    False     |    False     |
+|     Max FCN     |    False     |    False     |
+|     New Min     |    False     |    False     |
+-------------------------------------------------
+-------------------------------------------------
+Minos Status for y: VALID
+-------------------------------------------------
+|      Error      |     -0.5     |     0.5      |
+|      Valid      |     True     |     True     |
+|    At Limit     |    False     |    False     |
+|     Max FCN     |    False     |    False     |
+|     New Min     |    False     |    False     |
+-------------------------------------------------
+""" == out()

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -651,7 +651,7 @@ def test_get_param_states():
     assert m.get_param_states() == expected
 
     m.migrad()
-    assert m.get_param_states(initial=True) == expected
+    assert m.get_initial_param_states() == expected
 
     expected = [Struct(name='x',
                        number=0,

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -691,7 +691,6 @@ def test_latex_matrix():
     m = Minuit.from_array_func(Func9(), (0, 0), name=('x', 'y'),
                                pedantic=False, print_level=0)
     m.migrad()
-    print(m.latex_matrix())
     assert r"""%\usepackage[table]{xcolor} % include this for color
 %\usepackage{rotating} % include this for rotate header
 %\documentclass[xcolor=table]{beamer} % for beamer

--- a/iminuit/tests/test_latex.py
+++ b/iminuit/tests/test_latex.py
@@ -1,8 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from iminuit.latex import LatexTable
-from iminuit.tests.utils import equal_output
-from iminuit import Minuit
 
 
 def test_table():
@@ -63,27 +61,3 @@ def test_empty_table_with_headers():
         r'\end{tabular}',
     ])
     assert str(ltt) == expected
-
-
-def f1(x, y):
-    return (x - 2) ** 2 + (y - 1) ** 2 / 0.25 + 1
-
-
-def test_latex():
-    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=0)
-    m.migrad()
-    out = str(m.latex_matrix())
-    equal_output(out, """
-%\\usepackage[table]{xcolor} % include this for color
-%\\usepackage{rotating} % include this for rotate header
-%\\documentclass[xcolor=table]{beamer} % for beamer
-\\begin{tabular}{|c|c|c|}
-\\hline
-\\rotatebox{90}{} & \\rotatebox{90}{x} & \\rotatebox{90}{y}\\\\
-\\hline
-x & \\cellcolor[RGB]{255,117,117} 1.00 & \\cellcolor[RGB]{163,254,186} 0.00\\\\
-\\hline
-y & \\cellcolor[RGB]{163,254,186} 0.00 & \\cellcolor[RGB]{255,117,117} 1.00\\\\
-\\hline
-\\end{tabular}
-""")

--- a/iminuit/tests/test_latex.py
+++ b/iminuit/tests/test_latex.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from iminuit.latex import LatexTable
+from iminuit.tests.utils import equal_output
+from iminuit import Minuit
 
 
 def test_table():
@@ -61,3 +63,27 @@ def test_empty_table_with_headers():
         r'\end{tabular}',
     ])
     assert str(ltt) == expected
+
+
+def f1(x, y):
+    return (x - 2) ** 2 + (y - 1) ** 2 / 0.25 + 1
+
+
+def test_latex():
+    m = Minuit(f1, x=0, y=0, pedantic=False, print_level=0)
+    m.migrad()
+    out = str(m.latex_matrix())
+    equal_output(out, """
+%\\usepackage[table]{xcolor} % include this for color
+%\\usepackage{rotating} % include this for rotate header
+%\\documentclass[xcolor=table]{beamer} % for beamer
+\\begin{tabular}{|c|c|c|}
+\\hline
+\\rotatebox{90}{} & \\rotatebox{90}{x} & \\rotatebox{90}{y}\\\\
+\\hline
+x & \\cellcolor[RGB]{255,117,117} 1.00 & \\cellcolor[RGB]{163,254,186} 0.00\\\\
+\\hline
+y & \\cellcolor[RGB]{163,254,186} 0.00 & \\cellcolor[RGB]{255,117,117} 1.00\\\\
+\\hline
+\\end{tabular}
+""")

--- a/iminuit/tests/test_minimize.py
+++ b/iminuit/tests/test_minimize.py
@@ -1,4 +1,5 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 from iminuit import minimize
 from iminuit.tests.utils import assert_allclose, requires_dependency
 import numpy as np

--- a/iminuit/tests/test_util.py
+++ b/iminuit/tests/test_util.py
@@ -9,7 +9,8 @@ from iminuit.util import (fitarg_rename,
                           extract_fix,
                           remove_var,
                           arguments_from_docstring,
-                          )
+                          Struct)
+import pytest
 
 
 def test_fitarg_rename():
@@ -113,3 +114,17 @@ def test_arguments_from_docstring():
     s = 'Minuit.migrad( int ncall_me =10000, [resume=True, int nsplit=1])'
     a = arguments_from_docstring(s)
     assert a == ['ncall_me', 'resume', 'nsplit']
+
+
+def test_Struct():
+    s = Struct(a=1, b=2)
+    assert set(s.keys()) == {'a', 'b'}
+    assert s.a == 1
+    assert s.b == 2
+    s.a = 3
+    assert s.a == 3
+    with pytest.raises(AttributeError):
+        s.c
+    with pytest.raises(KeyError):
+        s['c']
+    assert s == Struct(a=3, b=2)

--- a/iminuit/tests/utils.py
+++ b/iminuit/tests/utils.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from numpy.testing import assert_allclose
 
 __all__ = [
     'requires_dependency',
@@ -36,9 +37,3 @@ def requires_dependency(name):
     reason = 'Missing dependency: {}'.format(name)
     import pytest
     return pytest.mark.skipif(skip_it, reason=reason)
-
-try:
-    from numpy.testing import assert_allclose
-except ImportError:
-    print('ERROR: Running the iminuit tests requires Numpy (for float comparisons)!')
-    raise

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-class Struct:
+class Struct(dict):
     """A Struct is a Python dict with tab completion.
 
     Example:
@@ -31,18 +31,16 @@ class Struct:
     >>> s.a
     42
     """
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-    def __str__(self):
-        return self.__dict__.__str__()
-
-    def __repr__(self):
-        return self.__str__()
-
-    def __getitem__(self, s):
-        return self.__dict__[s]
-
+    def __setattr__(self, key, value):
+        try:
+            self[key] = value
+        except KeyError:
+            raise AttributeError
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError
 
 def arguments_from_docstring(doc):
     """Parse first line of docstring for argument name.


### PR DESCRIPTION
This became another large patch, because I wanted to fully test any impact of what I did to `get_param_states`.

At the core, this patch removes `get_initial_param_state` and adds an optional keyword `initial` to `get_param_states`. If you call `get_param_states(initial=True)`, you get the initial parameter state, so exactly what `get_initial_param_state` was supposed to do.

I removed the two internal methods `_prepare_initial_param` and `_prepare_param`. The latter was identical to `get_param_states`. The former turned out to produce an inconsistent struct under certain conditions. I reimplemented the function in a consistent way.

Then I added unit tests for both versions of `get_param_states`. The method is also used by the frontends to print output on the console and in IPython, so I wanted to check that as well. When I looked into this, I found that the output of these frontends was not checked at all. They were only checked to be executable without errors. So I added new tests for the frontend output, which was a bit complicated because I had to capture and redirect output generated by these frontends. To make the frontends testable, I modified the class definition in a suitable way and added an abstract base class for the frontends, which enforces the interface.

While testing, I found a few minor cosmetic issues with the output generated by the frontends, which I fixed. The new output looks prettier and more consistent now.

Finally, I simplified the `Struct` class that iminuit uses to hold structured data such as the one provided by `get_param_states`. I also added a test for the Struct behavior.