### PR TITLE
fix for issue 198, draw an accurate MnContour contour instead of some…

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,7 +25,6 @@ These are the things you will use a lot:
     Minuit.mnprofile
     Minuit.draw_mnprofile
     Minuit.mncontour
-    Minuit.mncontour_grid
     Minuit.draw_mncontour
 
 Minuit

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -1351,60 +1351,16 @@ cdef class Minuit:
 
         return xminos, yminos, cerr.Points()  #using type coersion here
 
-    def mncontour_grid(self, x, y, bins=100, nsigma=2, numpoints=20,
-                       int sigma_res=4, edges=False):
-        """Compute gridded minos contour.
-
-        **Arguments:**
-
-            - **x**, **y** parameter name
-
-            - **bins** number of bins in the grid. The boundary of the grid is
-              selected automatically by the minos error computed. Default 100.
-
-            - **nsigma** number of sigma to draw. Default 2
-
-            - **numpoints** number of points to calculate mncontour for each
-              sigma points(there are sigma_res*nsigma total)
-
-            - **sigma_res** number of sigma level to calculate MnContours
-
-            - **edges** Return bin edges instead of mid value(pass True if you
-              want to draw it using pcolormesh)
-
-        **Returns:**
-
-            xgrid, ygrid, sigma, rawdata
-
-            rawdata is tuple of (x,y,sigma_level)
-
-        .. seealso::
-
-            :meth:`draw_mncontour`
-
-        .. plot:: pyplots/draw_mncontour.py
-            :include-source:
-
-        """
-        return _plotting.mncontour_grid(self, x, y, numpoints,
-                                        nsigma, sigma_res, bins, edges)
-
-    def draw_mncontour(self, x, y, bins=None, nsigma=2,
-                       numpoints=20, sigma_res=None):
+    def draw_mncontour(self, x, y, nsigma=2, numpoints=20):
         """Draw minos contour.
 
         **Arguments:**
 
             - **x**, **y** parameter name
 
-            - **bins** number of bin in contour grid. DEPRECATED: Value is ignored.
-
             - **nsigma** number of sigma contours to draw
 
             - **numpoints** number of points to calculate for each contour
-
-            - **sigma_res** number of sigma level to calculate MnContours.
-              Default 4. DEPRECATED: Value is ignored.
 
         **Returns:**
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -1334,7 +1334,7 @@ cdef class Minuit:
         cdef auto_ptr[MnContours] mnc = auto_ptr[MnContours](NULL)
         if self.grad_fcn is None:
             mnc = auto_ptr[MnContours](
-                new MnContours(deref(<FCNBase*> self.pyfcn),
+                new MnContours(deref(<FCNBase *> self.pyfcn),
                                deref(self.cfmin),
                                self.strategy))
         else:
@@ -1389,31 +1389,29 @@ cdef class Minuit:
         return _plotting.mncontour_grid(self, x, y, numpoints,
                                         nsigma, sigma_res, bins, edges)
 
-    def draw_mncontour(self, x, y, bins=100, nsigma=2,
-                       numpoints=20, sigma_res=4):
+    def draw_mncontour(self, x, y, bins=None, nsigma=2,
+                       numpoints=20, sigma_res=None):
         """Draw minos contour.
 
         **Arguments:**
 
             - **x**, **y** parameter name
 
-            - **bins** number of bin in contour grid.
+            - **bins** number of bin in contour grid. DEPRECATED: Value is ignored.
 
-            - **nsigma** number of sigma contour to draw
+            - **nsigma** number of sigma contours to draw
 
             - **numpoints** number of points to calculate for each contour
 
             - **sigma_res** number of sigma level to calculate MnContours.
-              Default 4.
+              Default 4. DEPRECATED: Value is ignored.
 
         **Returns:**
 
-            x, y, gridvalue, contour
+            contour
 
-            gridvalue is interorlated nsigma
         """
-        return _plotting.draw_mncontour(self, x, y, bins, nsigma,
-                                        numpoints, sigma_res)
+        return _plotting.draw_mncontour(self, x, y, nsigma, numpoints)
 
     def draw_contour(self, x, y, bins=20, bound=2, args=None,
                      show_sigma=False):

--- a/iminuit/_plotting.py
+++ b/iminuit/_plotting.py
@@ -5,14 +5,11 @@ import numpy as np
 
 __all__ = ['draw_contour',
            'draw_mncontour',
-           'draw_profile',
-           'mncontour_grid',
-           ]
+           'draw_profile']
 
 
 def draw_profile(self, vname, x, y, s=None, band=True, text=True):
     from matplotlib import pyplot as plt
-    import numpy as np
 
     x = np.array(x)
     y = np.array(y)
@@ -73,70 +70,6 @@ def draw_contour(self, x, y, bins=20, bound=2, args=None, show_sigma=False):
     plt.axvline(self.values[x], color='k', ls='--')
     plt.grid(True)
     return vx, vy, vz
-
-
-def mncontour_grid(self, x, y, numpoints=20, nsigma=2, sigma_res=4,
-                   bins=100, edges=False):
-    import numpy as np
-    from matplotlib import mlab
-    dfcn = []
-    xps = []
-    yps = []
-    sigmas = np.linspace(0.1, nsigma + 0.5, sigma_res * nsigma)
-    for i, this_sig in enumerate(sigmas):
-        xminos, yminos, pts = self.mncontour(x, y, numpoints=numpoints,
-                                             sigma=this_sig)
-        if len(pts) == 0:  # pragma: no cover
-            warnings.warn(RuntimeWarning(
-                'Fail mncontour for %s, %s, sigma=%f' % (x, y, this_sig))
-            )
-            continue
-
-        xp, yp = zip(*pts)
-        xps.append(xp)
-        yps.append(yp)
-        dfcn.append([this_sig] * len(pts))
-
-    # add the minimum in
-    xps.append([self.values[x]])
-    yps.append([self.values[y]])
-    dfcn.append([0])
-
-    # making grid data x ,y z
-    fx, fy, fz = np.hstack(xps), np.hstack(yps), np.hstack(dfcn)
-
-    maxx, minx = max(fx), min(fx)
-    maxy, miny = max(fy), min(fy)
-
-    # extend bound a bit
-    maxx += 0.05 * (maxx - minx)
-    minx -= 0.05 * (maxx - minx)
-    maxy += 0.05 * (maxy - miny)
-    miny -= 0.05 * (maxy - miny)
-
-    # need constant spacing for linear
-    xgrid = np.linspace(minx, maxx, bins)
-    ygrid = np.linspace(miny, maxy, bins)
-    xstep = (maxx - minx) / (1.0 * bins)
-    ystep = (maxy - miny) / (1.0 * bins)
-    # xgrid = np.arange(minx, maxx+xstep/2, xstep) # over cover
-    # ygrid = np.arange(miny, maxy+ystep/2, ystep)
-
-    with warnings.catch_warnings():
-        # suppress FutureWarning from matplotlib/tri/triangulation.py
-        warnings.filterwarnings("ignore", category=FutureWarning)
-        g = mlab.griddata(fx, fy, fz, xgrid, ygrid, interp='linear')
-
-    # return grid edges instead of mid point (for pcolor)
-    if edges:  # pragma: no cover
-        xgrid -= xstep / 2.
-        ygrid -= ystep / 2.
-        np.resize(xgrid, len(xgrid) + 1)
-        np.resize(ygrid, len(ygrid) + 1)
-        xgrid[-1] = xgrid[-2] + xstep / 2.
-        ygrid[-1] = ygrid[-2] + ystep / 2.
-
-    return xgrid, ygrid, g, (xps, yps, dfcn)
 
 
 def draw_mncontour(self, x, y, nsigma=2, numpoints=20):

--- a/iminuit/_plotting.py
+++ b/iminuit/_plotting.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import warnings
+import numpy as np
 
 __all__ = ['draw_contour',
            'draw_mncontour',
@@ -138,14 +139,21 @@ def mncontour_grid(self, x, y, numpoints=20, nsigma=2, sigma_res=4,
     return xgrid, ygrid, g, (xps, yps, dfcn)
 
 
-def draw_mncontour(self, x, y, bins=100, nsigma=2, numpoints=20, sig_res=4):
+def draw_mncontour(self, x, y, nsigma=2, numpoints=20):
     from matplotlib import pyplot as plt
+    # from matplotlib.collections import LineCollection
+    from matplotlib.contour import ContourSet
 
-    xgrid, ygrid, g, r = mncontour_grid(self, x, y, numpoints, nsigma, sig_res, bins)
-    # g[g.mask] = nsigma+1 #remove the mask
-
-    CS = plt.contour(xgrid, ygrid, g, range(1, nsigma + 1))
-    plt.clabel(CS, inline=1, fontsize=10)
+    c_val = []
+    c_pts = []
+    for sigma in range(1, nsigma + 1):
+        pts = self.mncontour(x, y, numpoints, sigma)[2]
+        # close curve
+        pts.append(pts[0])
+        c_val.append(sigma)
+        c_pts.append([pts])  # level can have more than one contour in mpl
+    cs = ContourSet(plt.gca(), c_val, c_pts)
+    plt.clabel(cs, inline=1, fontsize=10)
     plt.xlabel(x)
     plt.ylabel(y)
-    return xgrid, ygrid, g, CS
+    return cs


### PR DESCRIPTION
Addresses #198. Changes the implementation of Minuit.draw_contour to use Minuit.mncontour, which returns an exact contour, instead of Minuit.mncontour_grid, which returns an approximate contour, which is really bad if the parameters are highly correlated.

Technically, this is a breaking change, because I change the return value of draw_mncontour. I do not expect many people to actually use the return value. I could also break the arguments of Minuit.draw_mncontour, because it contains now unused keywords, but I decided against it to retain backward compatibility.