### PR TITLE
Modify parameter state

### DIFF
--- a/iminuit/Minuit2.pxi
+++ b/iminuit/Minuit2.pxi
@@ -109,7 +109,6 @@ cdef extern from "Minuit2/MnUserParameterState.h":
         void Add(char*, double)
 
         vector[MinuitParameter] MinuitParameters()
-        #MnUserParameters parameters()
         MnUserCovariance Covariance()
         MnGlobalCorrelationCoeff GlobalCC()
 
@@ -117,10 +116,12 @@ cdef extern from "Minuit2/MnUserParameterState.h":
         double Edm()
         unsigned int NFcn()
 
+        const MinuitParameter& Parameter(unsigned int)
+
         void Fix(unsigned int)
         void Release(unsigned int)
-        # void SetValue(unsigned int, double)
-        # void SetError(unsigned int, double)
+        void SetValue(unsigned int, double)
+        void SetError(unsigned int, double)
         void SetLimits(unsigned int, double, double)
         void SetUpperLimit(unsigned int, double)
         void SetLowerLimit(unsigned int, double)
@@ -129,11 +130,6 @@ cdef extern from "Minuit2/MnUserParameterState.h":
         bint IsValid()
         bint HasCovariance()
         bint HasGlobalCC()
-
-        double Value(char* name)
-        double Error(char* name)
-        void SetValue(char* name, double val)
-        void SetError(char* name, double err)
 
         unsigned int Index(char*)
         char*Name(unsigned int)

--- a/iminuit/Minuit2.pxi
+++ b/iminuit/Minuit2.pxi
@@ -102,7 +102,8 @@ cdef extern from "Minuit2/MnUserParameterState.h":
     cdef cppclass MnUserParameterState:
         MnUserParameterState()
         MnUserParameterState(MnUserParameterState mpst)
-        vector[double] Params()
+        operator=(MnUserParameterState)
+
         void Add(char*name, double val, double err)
         void Add(char*name, double val, double err, double, double)
         void Add(char*, double)
@@ -116,21 +117,23 @@ cdef extern from "Minuit2/MnUserParameterState.h":
         double Edm()
         unsigned int NFcn()
 
-        void Fix(char*)
-        void Release(char*)
-        void SetValue(char*, double)
-        void SetError(char*, double)
-        void SetLimits(char*, double, double)
-        void SetUpperLimit(char*, double)
-        void SetLowerLimit(char*, double)
-        void RemoveLimits(char*)
+        void Fix(unsigned int)
+        void Release(unsigned int)
+        # void SetValue(unsigned int, double)
+        # void SetError(unsigned int, double)
+        void SetLimits(unsigned int, double, double)
+        void SetUpperLimit(unsigned int, double)
+        void SetLowerLimit(unsigned int, double)
+        void RemoveLimits(unsigned int)
 
         bint IsValid()
         bint HasCovariance()
         bint HasGlobalCC()
 
-        double Value(char*)
-        double Error(char*)
+        double Value(char* name)
+        double Error(char* name)
+        void SetValue(char* name, double val)
+        void SetError(char* name, double err)
 
         unsigned int Index(char*)
         char*Name(unsigned int)

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -782,7 +782,6 @@ cdef class Minuit:
         """
 
         cdef MnHesse*hesse = NULL
-        cdef MnUserParameterState upst
         if self.print_level > 0: self.frontend.print_banner('HESSE')
         if self.cfmin is NULL:
             raise RuntimeError('Run migrad first')
@@ -799,7 +798,7 @@ cdef class Minuit:
                 self.last_upst,
                 maxcall
             )
-        if not upst.HasCovariance():
+        if not self.last_upst.HasCovariance():
             warn("HESSE Failed. Covariance and GlobalCC will not be available",
                  HesseFailedWarning)
         self.refreshInternalState()
@@ -997,7 +996,10 @@ cdef class Minuit:
         return self.np_matrix(correlation=False, skip_fixed=False)
 
     def is_fixed(self, vname):
-        """Check if variable *vname* is (initially) fixed"""
+        """Check if variable *vname* is fixed.
+
+        Note that `Minuit.fixed` was added to fix and release parameters.
+        """
         return self.fixed[vname]
 
     #dealing with frontend conversion

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -1143,16 +1143,15 @@ cdef class Minuit:
     def matrix_accurate(self):
         """Check if covariance (of the last migrad) is accurate"""
         return self.cfmin is not NULL and \
-               self.cfmin.HasAccurateCovar()
+            self.cfmin.HasAccurateCovar()
 
     def list_of_fixed_param(self):
         """List of (initially) fixed parameters"""
-        return [k for k in self.fixed if self.fixed[k]]
+        return [name for (name, is_fixed) in self.fixed.items() if is_fixed]
 
     def list_of_vary_param(self):
         """List of (initially) float varying parameters"""
-        return [k for k in self.fixed if not self.fixed[k]]
-
+        return [name for (name, is_fixed) in self.fixed.items() if not is_fixed]
 
     # Various utility functions
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -188,6 +188,9 @@ cdef class ArgsView:
             raise IndexError
         self._state.SetValue(i, value)
 
+    def copy(self):
+        return tuple(self)
+
     def __str__(self):
         return 'ArgsView[' + ', '.join(str(x) for x in self) + ']'
 

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -106,6 +106,7 @@ cdef int check_extra_args(parameters, kwd) except -1:
 
 # Helper classes
 cdef class NameIter:
+    """Iterator over parameter names in correct order"""
     cdef MnUserParameterStatePtr _state
     cdef unsigned int i
     cdef unsigned int n
@@ -126,6 +127,10 @@ cdef class NameIter:
 
 
 cdef class BasicView:
+    """Dict-like view of parameter state.
+
+    Derived classes need to implement methods _set and _get to access
+    specific properties of the parameter state."""
     cdef MnUserParameterStatePtr _state
     cdef dict _name2idx
 
@@ -169,6 +174,7 @@ cdef class BasicView:
 
 
 cdef class ArgsView:
+    """List-like view of parameter values."""
     cdef MnUserParameterStatePtr _state
     cdef unsigned int _npar
 
@@ -196,7 +202,7 @@ cdef class ArgsView:
 
 
 cdef class ValueView(BasicView):
-
+    """Dict-like view of parameter values."""
     def _get(self, unsigned int i):
         return self._state.Parameter(i).Value()
 
@@ -205,7 +211,7 @@ cdef class ValueView(BasicView):
 
 
 cdef class ErrorView(BasicView):
-
+    """Dict-like view of parameter errors."""
     def _get(self, unsigned int i):
         return self._state.Parameter(i).Error()
 
@@ -214,7 +220,7 @@ cdef class ErrorView(BasicView):
 
 
 cdef class FixedView(BasicView):
-
+    """Dict-like view of whether parameters are fixed."""
     def _get(self, unsigned int i):
         return self._state.Parameter(i).IsFixed()
 

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -764,3 +764,14 @@ def test_modify_param_state():
     m.migrad()
     assert_allclose(m.np_values(), [2, 5], atol=1e-2)
     assert_allclose(m.np_errors(), [2, 1], atol=1e-2)
+
+
+def test_view_lifetime():
+    m = Minuit(func3, x=1, y=2, pedantic=False)
+    val = m.values
+    arg = m.args
+    del m
+    val['x'] = 3  # should not segfault
+    assert val['x'] == 3
+    arg[0] = 5  # should not segfault
+    assert arg[0] == 5

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -764,6 +764,10 @@ def test_modify_param_state():
     m.migrad()
     assert_allclose(m.np_values(), [2, 5], atol=1e-2)
     assert_allclose(m.np_errors(), [2, 1], atol=1e-2)
+    m.values['y'] = 6
+    m.hesse()  # does not change minimum
+    assert_allclose(m.np_values(), [2, 6], atol=1e-2)
+    assert_allclose(m.np_errors(), [2, 1], atol=1e-2)
 
 
 def test_view_lifetime():

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -306,12 +306,12 @@ def test_fix_param(grad):
 
     assert m.is_fixed('x') is False
     assert m.is_fixed('y') is True
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         m.is_fixed('a')
 
 
 def test_fitarg_oneside():
-    m = Minuit(func4, print_level=-1, y=10., fix_y=True, limit_x=(None, 20.),
+    m = Minuit(func4, print_level=0, y=10., fix_y=True, limit_x=(None, 20.),
                pedantic=False)
     fitarg = m.fitarg
     assert_allclose(fitarg['y'], 10.)
@@ -321,8 +321,8 @@ def test_fitarg_oneside():
 
     fitarg = m.fitarg
 
-    assert_allclose(fitarg['y'], 10.)
     assert_allclose(fitarg['x'], 2., atol=1e-2)
+    assert_allclose(fitarg['y'], 10., atol=1e-2)
     assert_allclose(fitarg['z'], 7., atol=1e-2)
 
     assert 'error_y' in fitarg
@@ -479,9 +479,8 @@ def test_reverse_limit():
     def f(x, y, z):
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
-    m = Minuit(f, limit_x=(3., 2.), pedantic=False, print_level=0)
     with pytest.raises(ValueError):
-        m.migrad()
+        m = Minuit(f, limit_x=(3., 2.), pedantic=False, print_level=0)
 
 
 class TestOutputInterface:

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -294,7 +294,7 @@ def test_fix_param(grad):
     for b in (True, False):
         assert_allclose(m.matrix(skip_fixed=b), [[4, 0], [0, 1]], atol=1e-4)
     m.print_all_minos()
-    # now fix z = 10
+    # now fix y = 10
     m = Minuit(func3, y=10., fix_y=True, **kwds)
     m.migrad()
     assert_allclose(m.np_values(), (2, 10), rtol=1e-2)
@@ -749,3 +749,18 @@ def test_perfect_correlation():
     assert fmin.has_accurate_covar is False
     assert fmin.has_posdef_covar is False
     assert fmin.has_made_posdef_covar is True
+
+
+def test_modify_param_state():
+    m = Minuit(func3, x=1, y=2, fix_y=True, pedantic=False)
+    m.migrad()
+    assert_allclose(m.np_values(), [2, 2], atol=1e-2)
+    assert_allclose(m.np_errors(), [2, 1], atol=1e-2)
+    m.fixed['y'] = False
+    m.values['x'] = 1
+    m.errors['x'] = 1
+    assert_allclose(m.np_values(), [1, 2], atol=1e-2)
+    assert_allclose(m.np_errors(), [1, 1], atol=1e-2)
+    m.migrad()
+    assert_allclose(m.np_values(), [2, 5], atol=1e-2)
+    assert_allclose(m.np_errors(), [2, 1], atol=1e-2)

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -3,7 +3,7 @@ import sys
 from glob import glob
 from time import time
 import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
+from nbconvert.preprocessors import ExecutePreprocessor
 
 STATUS_FAIL, STATUS_SUCCEED = 1, 0
 


### PR DESCRIPTION
Addresses #230 #105 

It is one of the key features of Minuit is that you can modify the parameter state. A common approach is to fix some parameters initially, then minimize only free parameters, then release all parameters and fit all together. Example:

```
m = Minuit(some_func, x=1, y=2, fix_y=True)
m.migrad()  # fit only x
m.fixed['y'] = False
m.migrad()  # resume fit, now with floating y
```

So far this was not possible, because there was no way to interact with the parameter state in Minuit. The proposed workaround was to create a new `Minuit` instance. This was not intuitive for many people, and actually a step back from precursors like pyminuit, which allowed to modify the fit state.

So I fixed this by changing the classes that are returned when you call `Minuit.args`, `Minuit.values`, `Minuit.errors` from tuples and dicts to tuple-like and dict-like objects which are actually views of the internal parameter state. And I added a new field `Minuit.fixed`, a dict-like object to fix or release parameters. Now the code example above works as expected and many new ways of interactively working with Minuit become more straight-forward.

So these new views mimic a normal dict by their interface, but when you set something it actually changes the internal cpp state in the `Minuit` instance. Using views actually makes the code in `Minuit` simpler in several places, because it is not necessary to manually update `args`, `values`, `errors`, and `fixed` to the internal cpp state. They are automatically kept consistent, which removes the burden from the programmer to make sure they are.

If you want to make real copies of `args`, `values`, etc. you can do that. There is a `.copy` method, and you can also do something like `dict(m.values)` to get a copy.

The new classes have docstrings and a new test was written to check the new behavior. The change is fully backward-compatible.