### PR TITLE
Test notebooks in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
       pip uninstall -y cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
-  - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme, jupyter; fi
+  - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme jupyter; fi
   - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_install:
       pip uninstall -y cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
-  - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme jupyter; fi
-  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi
+  - if [[ $BUILD == DOCS ]]; then pip install numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy scipy matplotlib; fi
 
 install:
   - python setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
       pip uninstall -y cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
-  - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme; fi
+  - if [[ $BUILD == DOCS ]]; then pip install matplotlib sphinx sphinx_rtd_theme, jupyter; fi
   - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ script:
   - if [[ $BUILD == TEST ]]; then make test; fi
   - if [[ $BUILD == COVERAGE ]]; then make coverage; fi
   - if [[ $BUILD == DOCS ]]; then make doc; fi
+  - if [[ $BUILD == DOCS ]]; then make test-notebooks; fi

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ iminuit/_libiminuit.so: $(wildcard Minuit/src/*.cxx Minuit/inc/*/*.h iminuit/*.p
 test: build
 	python -m pytest -v iminuit
 
+test-notebooks: build
+	python test_notebooks.py
+
 coverage: build
 	python -m pytest -v iminuit --cov iminuit --cov-report html --cov-report term-missing --cov-report xml
 

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -98,6 +98,12 @@ Run the tests:
 
     $ make test
 
+Run the notebook tests:
+
+.. code-block:: bash
+
+    $ make test-notebooks
+
 Run the tests with coverage report:
 
 .. code-block:: bash

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -25,8 +25,15 @@ def test_notebook(filename):
 
 def test_all_notebooks():
     filenames = sorted(glob("tutorial/*.ipynb"))
+    broken_notebooks = [
+        # See https://github.com/iminuit/iminuit/pull/245#issuecomment-402431753
+        'tutorial/hard-core-tutorial.ipynb',
+    ]
     status_total = STATUS_SUCCEED
     for filename in filenames:
+        if filename in broken_notebooks:
+            print('Skipping broken tutorial notebook: {}'.format(filename))
+            continue
         status = test_notebook(filename)
         if status == STATUS_FAIL:
             status_total = STATUS_FAIL

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -5,6 +5,8 @@ from time import time
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 
+STATUS_FAIL, STATUS_SUCCEED = 1, 0
+
 def test_notebook(filename):
     t_start = time()
     with open(filename) as f:
@@ -13,20 +15,27 @@ def test_notebook(filename):
         ep = ExecutePreprocessor(timeout=1000, kernel_name='python3')
         try:
             ep.preprocess(nb, {'metadata': {'path': 'tutorial/'}})
-        except CellExecutionError as e:
+        except Exception as e:
             print("{0} [FAILED]\n{1}".format(filename, e))
-            exit(1)
+            return STATUS_FAIL
         print("{0} [PASSED]".format(filename))
     t_run = time() - t_start
-    print('Execution time for {}: {} sec'.format(filename, t_run))
+    print('Execution time for {}: {:.2f} sec'.format(filename, t_run))
+    return STATUS_SUCCEED
 
 def test_all_notebooks():
     filenames = sorted(glob("tutorial/*.ipynb"))
+    status_total = STATUS_SUCCEED
     for filename in filenames:
-        test_notebook(filename)
+        status = test_notebook(filename)
+        if status == STATUS_FAIL:
+            status_total = STATUS_FAIL
+    
+    print('Total notebook execution status: {}'.format(status_total))
+    return status_total
 
 if __name__ == '__main__':
     print('Starting notebook tests')
     print('Python executable: {}'.format(sys.executable))
     print('Python version: {}'.format(sys.version))
-    test_all_notebooks()
+    exit(test_all_notebooks())

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -1,0 +1,32 @@
+"""Test if tutorial notebooks execute without error."""
+import sys
+from glob import glob
+from time import time
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
+
+def test_notebook(filename):
+    t_start = time()
+    with open(filename) as f:
+        print("Executing notebook : {0}".format(filename))
+        nb = nbformat.read(f, as_version=4)
+        ep = ExecutePreprocessor(timeout=1000, kernel_name='python3')
+        try:
+            ep.preprocess(nb, {'metadata': {'path': 'tutorial/'}})
+        except CellExecutionError as e:
+            print("{0} [FAILED]\n{1}".format(filename, e))
+            exit(1)
+        print("{0} [PASSED]".format(filename))
+    t_run = time() - t_start
+    print('Execution time for {}: {} sec'.format(filename, t_run))
+
+def test_all_notebooks():
+    filenames = sorted(glob("tutorial/*.ipynb"))
+    for filename in filenames:
+        test_notebook(filename)
+
+if __name__ == '__main__':
+    print('Starting notebook tests')
+    print('Python executable: {}'.format(sys.executable))
+    print('Python version: {}'.format(sys.version))
+    test_all_notebooks()

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -12,7 +12,7 @@ def test_notebook(filename):
     with open(filename) as f:
         print("Executing notebook : {0}".format(filename))
         nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(timeout=1000, kernel_name='python3')
+        ep = ExecutePreprocessor(timeout=1000, kernel_name='python')
         try:
             ep.preprocess(nb, {'metadata': {'path': 'tutorial/'}})
         except Exception as e:


### PR DESCRIPTION
If we keep notebooks, I think we should test them in CI.
Otherwise it's very hard to maintain the content, even for a stable package like this one.

See #15. I'll keep that closed, because that was a very old attempt to implement that. By now the Jupyter tooling is better. Assigning this to myself under the v1.3 milestone.