### PR TITLE
Add CI that builds and tests sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ matrix:
         - python: 2.7
           env: BUILD=SDIST
 
-        - python: 3.6
-          env: BUILD=CONDA
+          # TODO: add this (travis-ci not running today, so disabling for now)
+#        - python: 3.6
+#          env: BUILD=CONDA
 
 # TODO: add osx builds; (setting up multi-os envs isn't trivial, see below)
 #        - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,10 @@ sudo: false
 matrix:
     include:
         - python: 2.7
-          env: BUILD=TEST
-
-        - python: 2.7
-          env: BUILD=DOCS
+          env: BUILD=ALL
 
         - python: 3.5
-          env: BUILD=TEST
-
-        - python: 3.5
-          env: BUILD=DOCS
+          env: BUILD=ALL
 
         - python: 3.5
           env: BUILD=COVERAGE
@@ -25,7 +19,13 @@ matrix:
         - python: 3.5
           env: BUILD=NO_CYTHON
 
-        # TODO: add tests on Mac
+        - os: osx
+          python: 2.7
+          env: BUILD=ALL
+
+        - os: osx
+          python: 3.5
+          env: BUILD=ALL
 
         # TODO: add tests for Python from conda
 
@@ -36,15 +36,15 @@ before_install:
       pip uninstall -y cython;
     fi
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
-  - if [[ $BUILD == DOCS ]]; then pip install numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
-  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]]; then pip install pytest pytest-cov numpy scipy matplotlib; fi
+  - if [[ $BUILD == DOCS ]] || [[ $BUILD == ALL ]]; then pip install numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]] || [[ $BUILD == ALL ]]; then pip install pytest pytest-cov numpy scipy matplotlib; fi
 
 install:
   - python setup.py build_ext -i
   - python setup.py install
 
 script:
-  - if [[ $BUILD == TEST ]]; then make test; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == ALL ]]; then make test; fi
   - if [[ $BUILD == COVERAGE ]]; then make coverage; fi
-  - if [[ $BUILD == DOCS ]]; then make doc; fi
-  - if [[ $BUILD == DOCS ]]; then make test-notebooks; fi
+  - if [[ $BUILD == DOCS ]] || [[ $BUILD == ALL ]]; then make doc; fi
+  - if [[ $BUILD == DOCS ]] || [[ $BUILD == ALL ]]; then make test-notebooks; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
         - python: 3.5
           env: BUILD=ALL
 
+        - python: 3.7-dev
+          env: BUILD=TEST
+
         - python: 3.5
           env: BUILD=COVERAGE
 
@@ -30,6 +33,11 @@ matrix:
         # TODO: add tests for conda build and install of conda package
 
 before_install:
+  # https://docs.travis-ci.com/user/multi-os/
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python  ; fi
+
+
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install cython ipython numpy matplotlib; fi
   - if [[ $BUILD == ALL ]]; then pip install cython numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
   - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]] || [[ $BUILD == ALL ]]; then pip install cython pytest pytest-cov numpy scipy matplotlib; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
         - python: 2.7
           env: BUILD=SDIST
 
+        - python: 3.6
+          env: BUILD=CONDA
+
 # TODO: add osx builds; (setting up multi-os envs isn't trivial, see below)
 #        - os: osx
 #          python: 2.7
@@ -49,9 +52,21 @@ before_install:
   - if [[ $BUILD == ALL ]]; then pip install cython numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
   - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]] || [[ $BUILD == ALL ]]; then pip install cython pytest pytest-cov numpy scipy matplotlib; fi
 
+  - if [[ $BUILD == CONDA ]]; then
+      # Set up miniconda
+      - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      - bash miniconda.sh -b -p $HOME/miniconda
+      - export PATH="$HOME/miniconda/bin:$PATH"
+      - hash -r
+      - conda config --set always_yes yes --set changeps1 no
+      - conda update -q conda
+      - conda info -a
+    fi
+
 #install:
 #  - python setup.py build_ext -i
 #  - python setup.py install
+
 
 script:
   - if [[ $BUILD == TEST ]] || [[ $BUILD == ALL ]]; then make test; fi
@@ -65,4 +80,16 @@ script:
       cd dist;
       pip install iminuit-1.3.tar.gz;
       python -c 'import iminuit; iminuit.test()';
+    fi
+
+  - if [[ $BUILD == CONDA ]]; then
+      # From https://conda.io/docs/bdist_conda.html
+      # bdist_conda must be installed into a root conda environment,
+      # as it imports conda and conda_build. It is included as part of the conda build package.
+      conda install -n root conda-build Cython numpy;
+      conda info;
+      conda --version;
+      conda build --version;
+      make conda;
+#      source activate root;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
         - python: 3.5
           env: BUILD=ALL
 
+        - python: 3.7
+          env: BUILD=ALL
+
         - python: 3.5
           env: BUILD=COVERAGE
 
@@ -17,7 +20,7 @@ matrix:
           env: BUILD=NO_EXTRA_DEPS
 
         - python: 3.5
-          env: BUILD=NO_CYTHON
+          env: BUILD=SDIST
 
         - os: osx
           python: 2.7
@@ -27,24 +30,23 @@ matrix:
           python: 3.5
           env: BUILD=ALL
 
-        # TODO: add tests for Python from conda
+        # TODO: add tests for conda build and install of conda package
 
 before_install:
-  - pip install setuptools Cython
-  - if [[ $BUILD == NO_CYTHON ]]; then
-      python setup.py sdist;
-      pip uninstall -y cython;
-    fi
-  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install IPython numpy matplotlib; fi
-  - if [[ $BUILD == DOCS ]] || [[ $BUILD == ALL ]]; then pip install numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
-  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]] || [[ $BUILD == ALL ]]; then pip install pytest pytest-cov numpy scipy matplotlib; fi
+  - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install cython ipython numpy matplotlib; fi
+  - if [[ $BUILD == ALL ]]; then pip install cython numpy scipy matplotlib sphinx sphinx_rtd_theme jupyter; fi
+  - if [[ $BUILD == TEST ]] || [[ $BUILD == COVERAGE ]] || [[ $BUILD == ALL ]]; then pip install cython pytest pytest-cov numpy scipy matplotlib; fi
 
-install:
-  - python setup.py build_ext -i
-  - python setup.py install
+#install:
+#  - python setup.py build_ext -i
+#  - python setup.py install
 
 script:
   - if [[ $BUILD == TEST ]] || [[ $BUILD == ALL ]]; then make test; fi
   - if [[ $BUILD == COVERAGE ]]; then make coverage; fi
-  - if [[ $BUILD == DOCS ]] || [[ $BUILD == ALL ]]; then make doc; fi
-  - if [[ $BUILD == DOCS ]] || [[ $BUILD == ALL ]]; then make test-notebooks; fi
+  - if [[ $BUILD == ALL ]]; then make doc; fi
+  - if [[ $BUILD == ALL ]]; then make test-notebooks; fi
+  - if [[ $BUILD == SDIST ]]; then
+      python setup.py sdist;
+      pip uninstall -y cython;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ matrix:
         - python: 3.5
           env: BUILD=ALL
 
-        - python: 3.7-dev
-          env: BUILD=TEST
+        # See https://github.com/iminuit/iminuit/issues/270
+#        - python: 3.7-dev
+#          env: BUILD=TEST
 
         - python: 3.5
           env: BUILD=COVERAGE
@@ -22,20 +23,23 @@ matrix:
         - python: 3.5
           env: BUILD=SDIST
 
-        - os: osx
-          python: 2.7
-          env: BUILD=ALL
-
-        - os: osx
-          python: 3.5
-          env: BUILD=ALL
+# TODO: add osx builds; (setting up multi-os envs isn't trivial, see below)
+#        - os: osx
+#          python: 2.7
+#          env: BUILD=ALL
+#
+#        - os: osx
+#          python: 3.5
+#          env: BUILD=ALL
 
         # TODO: add tests for conda build and install of conda package
 
 before_install:
-  # https://docs.travis-ci.com/user/multi-os/
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python  ; fi
+# https://docs.travis-ci.com/user/multi-os/
+# This might also be useful:
+# https://stackoverflow.com/questions/45257534/how-can-i-build-a-python-project-with-osx-environment-on-travis
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python  ; fi
 
 
   - if [[ $BUILD != NO_EXTRA_DEPS ]]; then pip install cython ipython numpy matplotlib; fi
@@ -52,6 +56,10 @@ script:
   - if [[ $BUILD == ALL ]]; then make doc; fi
   - if [[ $BUILD == ALL ]]; then make test-notebooks; fi
   - if [[ $BUILD == SDIST ]]; then
+      make clean;
       python setup.py sdist;
       pip uninstall -y cython;
+      cd dist;
+      pip install iminuit-1.3.tar.gz;
+      python -m 'import iminuit; iminuit.test()'
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
         - python: 3.5
           env: BUILD=SDIST
 
+        - python: 2.7
+          env: BUILD=SDIST
+
 # TODO: add osx builds; (setting up multi-os envs isn't trivial, see below)
 #        - os: osx
 #          python: 2.7
@@ -61,5 +64,5 @@ script:
       pip uninstall -y cython;
       cd dist;
       pip install iminuit-1.3.tar.gz;
-      python -m 'import iminuit; iminuit.test()'
+      python -c 'import iminuit; iminuit.test()';
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
         - python: 3.5
           env: BUILD=ALL
 
-        - python: 3.7
-          env: BUILD=ALL
-
         - python: 3.5
           env: BUILD=COVERAGE
 

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,6 @@ pylint:
 	pylint -E $(PROJECT)/ -d E1103,E0611,E1101 \
 	       --ignore="" -f colorized \
 	       --msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})'
+
+conda:
+	python setup.py bdist_conda

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ but is most commonly used for likelihood fits of models to data,
 and to get model parameter error estimates from likelihood profile analysis.
 
 * Code: https://github.com/iminuit/iminuit
-* Documentation: http://iminuit.readthedocs.org/
+* Documentation: https://iminuit.readthedocs.io
 * Mailing list: https://groups.google.com/forum/#!forum/iminuit
 * PyPI: https://pypi.org/project/iminuit/
 * License: MINUIT is LGPL and iminuit is MIT

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,10 @@
-
-.. image:: https://travis-ci.org/iminuit/iminuit.svg?branch=master
-   :target: https://travis-ci.org/iminuit/iminuit
-.. image:: https://ci.appveyor.com/api/projects/status/bp9qt5xfvwd642n3?svg=true
-   :target: https://ci.appveyor.com/project/iminuit/iminuit
-.. image:: https://img.shields.io/pypi/v/iminuit.svg
-   :target: https://pypi.python.org/pypi/iminuit
-.. image:: https://img.shields.io/pypi/dm/iminuit.svg
-   :target: https://pypi.python.org/pypi/iminuit
-
 iminuit
 -------
 
 MINUIT from Python - Fitting like a boss
 
 `iminuit` is a Python interface to the `MINUIT` C++ package.
+
 It can be used as a general robust function minimisation method,
 but is most commonly used for likelihood fits of models to data,
 and to get model parameter error estimates from likelihood profile analysis.
@@ -24,3 +15,39 @@ and to get model parameter error estimates from likelihood profile analysis.
 * PyPI: https://pypi.org/project/iminuit/
 * License: MINUIT is LGPL and iminuit is MIT
 * Citation: https://github.com/iminuit/iminuit/blob/master/CITATION
+
+iminuit
+=======
+
+MINUIT from Python - Fitting like a boss
+
+`iminuit` is a Python interface to the `MINUIT` C++ package.
+
+It can be used as a general robust function minimisation method,
+but is most commonly used for likelihood fits of models to data,
+and to get model parameter error estimates from likelihood profile analysis.
+
+* Code: https://github.com/iminuit/iminuit
+* Documentation: http://iminuit.readthedocs.org/
+* Mailing list: https://groups.google.com/forum/#!forum/iminuit
+* PyPI: https://pypi.org/project/iminuit/
+* License: MINUIT is LGPL and iminuit is MIT
+* Citation: https://github.com/iminuit/iminuit/blob/master/CITATION
+
+In a nutshell
+-------------
+
+.. code-block:: python
+
+    from iminuit import Minuit
+
+    def f(x, y, z):
+        return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
+
+    m = Minuit(f)
+
+    m.migrad()  # run optimiser
+    print(m.values)  # {'x': 2,'y': 3,'z': 4}
+
+    m.hesse()   # run covariance estimator
+    print(m.errors)  # {'x': 1,'y': 1,'z': 1}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,6 +6,7 @@ iminuit
 MINUIT from Python - Fitting like a boss
 
 `iminuit` is a Python interface to the `MINUIT` C++ package.
+
 It can be used as a general robust function minimisation method,
 but is most commonly used for likelihood fits of models to data,
 and to get model parameter error estimates from likelihood profile analysis.

--- a/iminuit/__init__.py
+++ b/iminuit/__init__.py
@@ -42,5 +42,5 @@ def test(args=None):
     """
     # http://pytest.org/latest/usage.html#calling-pytest-from-python-code
     import pytest
-    args = '--pyargs iminuit'
+    args = ['-v', '--pyargs', 'iminuit']
     pytest.main(args)

--- a/iminuit/tests/test_frontend.py
+++ b/iminuit/tests/test_frontend.py
@@ -19,7 +19,6 @@ def f1(x, y):
 
 @requires_dependency('IPython')
 def test_html(capsys):
-
     def out():
         return capsys.readouterr()[0]
 
@@ -392,7 +391,6 @@ y & \cellcolor[RGB]{163,254,186} 0.00 & \cellcolor[RGB]{255,117,117} 1.00\\
 
 
 def test_console(capsys):
-
     def out():
         return capsys.readouterr()[0]
 

--- a/iminuit/tests/test_iminuit.py
+++ b/iminuit/tests/test_iminuit.py
@@ -5,6 +5,7 @@ from iminuit.tests.utils import assert_allclose
 from iminuit import Minuit
 from iminuit.util import Struct
 import numpy as np
+
 parametrize = pytest.mark.parametrize
 
 
@@ -48,7 +49,7 @@ def func4_grad(x, y, z):
     dfdx = 0.4 * (x - 2.)
     dfdy = 0.2 * (y - 5.)
     dfdz = 0.5 * (z - 7.)
-    return (dfdx, dfdy, dfdz)
+    return dfdx, dfdy, dfdz
 
 
 def func5(x, long_variable_name_really_long_why_does_it_has_to_be_this_long, z):
@@ -59,11 +60,11 @@ def func5_grad(x, long_variable_name_really_long_why_does_it_has_to_be_this_long
     dfdx = 2 * x
     dfdy = 2 * long_variable_name_really_long_why_does_it_has_to_be_this_long
     dfdz = 2 * z
-    return (dfdx, dfdy, dfdz)
+    return dfdx, dfdy, dfdz
 
 
-def func6(x, m, s, A):
-    return A / ((x - m) ** 2 + s ** 2)
+def func6(x, m, s, a):
+    return a / ((x - m) ** 2 + s ** 2)
 
 
 def func7(*args):  # no signature
@@ -83,7 +84,7 @@ class Func9:
         sx = 2
         sy = 1
         corr = 0.5
-        cov = (sx**2, corr * sx * sy), (corr * sx * sy, sy**2)
+        cov = (sx ** 2, corr * sx * sy), (corr * sx * sy, sy ** 2)
         self.cinv = np.linalg.inv(cov)
 
     def __call__(self, x):
@@ -96,9 +97,9 @@ data_y = [0.552, 0.735, 0.846, 0.875, 1.059, 1.675, 1.622, 2.928,
 data_x = list(range(len(data_y)))
 
 
-def chi2(m, s, A):
+def chi2(m, s, a):
     """Chi2 fitting routine"""
-    return sum(((func6(x, m, s, A) - y) ** 2 for x, y in zip(data_x, data_y)))
+    return sum(((func6(x, m, s, a) - y) ** 2 for x, y in zip(data_x, data_y)))
 
 
 def functesthelper(f, **kwds):
@@ -480,7 +481,7 @@ def test_reverse_limit():
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
     with pytest.raises(ValueError):
-        m = Minuit(f, limit_x=(3., 2.), pedantic=False, print_level=0)
+        Minuit(f, limit_x=(3., 2.), pedantic=False, print_level=0)
 
 
 class TestOutputInterface:
@@ -553,10 +554,10 @@ class TestOutputInterface:
 
 def test_chi2_fit():
     """Fit a curve to data."""
-    m = Minuit(chi2, s=2., error_A=0.1, errordef=0.01,
+    m = Minuit(chi2, s=2., error_a=0.1, errordef=0.01,
                print_level=0, pedantic=False)
     m.migrad()
-    output = [round(10 * m.values['A']), round(100 * m.values['s']),
+    output = [round(10 * m.values['a']), round(100 * m.values['s']),
               round(100 * m.values['m'])]
     expected = [round(10 * 64.375993), round(100 * 4.267970),
                 round(100 * 9.839172)]
@@ -611,7 +612,7 @@ def test_num_call():
 
 
 def test_set_error_def():
-    m = Minuit(lambda x: x**2, pedantic=False, print_level=0, errordef=1)
+    m = Minuit(lambda x: x ** 2, pedantic=False, print_level=0, errordef=1)
     m.migrad()
     m.hesse()
     assert_allclose(m.errors["x"], 1)
@@ -706,7 +707,6 @@ y & \cellcolor[RGB]{209,185,152} 0.50 & \cellcolor[RGB]{255,117,117} 1.00\\
 
 
 def test_non_analytical_function():
-
     class Func:
         i = 0
 
@@ -730,7 +730,6 @@ def test_function_without_local_minimum():
 # Bug in Minuit2, this needs to be fixed in upstream ROOT
 @pytest.mark.xfail(strict=True)
 def test_function_with_maximum():
-
     def func(a):
         return -a ** 2
 

--- a/iminuit/tests/test_plot.py
+++ b/iminuit/tests/test_plot.py
@@ -6,6 +6,7 @@ from iminuit.tests.utils import assert_allclose, requires_dependency
 
 try:
     import matplotlib as mpl
+
     mpl.use('Agg')
 except ImportError:
     pass
@@ -24,6 +25,7 @@ def m():
     assert_allclose(m.values['x'], 1, atol=1e-3)
     assert_allclose(m.values['y'], 1, atol=1e-3)
     return m
+
 
 @requires_dependency('matplotlib')
 def test_profile(m):

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 import os
 from os.path import dirname, join, exists
 from glob import glob
-
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-
 from distutils.ccompiler import CCompiler
 from distutils.unixccompiler import UnixCCompiler
 from distutils.msvccompiler import MSVCCompiler
@@ -93,8 +90,7 @@ except ImportError:
     numpy_header = []
 
 libiminuit = Extension('iminuit._libiminuit',
-                       sources=(glob(join(cwd, 'iminuit/*' + ext)) +
-                                minuit_src),
+                       sources=(glob(join(cwd, 'iminuit/*' + ext)) + minuit_src),
                        include_dirs=minuit_header + numpy_header,
                        define_macros=[('WARNINGMSG', '1')])
 extensions = [libiminuit]
@@ -144,8 +140,8 @@ setup(
         'Topic :: Scientific/Engineering :: Mathematics',
         'Intended Audience :: Science/Research',
         'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: GNU General Public License (GPL)',
-        'License :: OSI Approved :: MIT License'
+        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+        'License :: OSI Approved :: MIT License',
     ],
     cmdclass={
         'build_ext': SmartBuildExt,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ from distutils.unixccompiler import UnixCCompiler
 from distutils.msvccompiler import MSVCCompiler
 import distutils.ccompiler
 
-
 # turn off warnings raised by Minuit and generated Cython code that need
 # to be fixed in the original code bases of Minuit and Cython
 compiler_opts = {
@@ -61,7 +60,6 @@ def lazy_compile(self, sources, output_dir=None, macros=None,
 # monkey-patching lazy_compile into CCompiler
 distutils.ccompiler.CCompiler.compile = lazy_compile
 
-
 # Static linking
 cwd = dirname(__file__)
 minuit_src = glob(join(cwd, 'Minuit/src/*.cxx'))
@@ -89,6 +87,7 @@ ext = '.pyx' if USE_CYTHON else '.cpp'
 
 try:
     import numpy
+
     numpy_header = [numpy.get_include()]
 except ImportError:
     numpy_header = []
@@ -136,8 +135,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: C++',
         'Programming Language :: Cython',
         'Programming Language :: Python :: Implementation :: CPython',
@@ -149,7 +148,6 @@ setup(
         'License :: OSI Approved :: MIT License'
     ],
     cmdclass={
-        # 'coverage': CoverageCommand,
         'build_ext': SmartBuildExt,
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Intended Audience :: Science/Research',
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
         'License :: OSI Approved :: MIT License',
     ],

--- a/status.rst
+++ b/status.rst
@@ -1,0 +1,12 @@
+# Status
+
+Continuous integration status; only of interest for developers.
+
+.. image:: https://travis-ci.org/iminuit/iminuit.svg?branch=master
+   :target: https://travis-ci.org/iminuit/iminuit
+.. image:: https://ci.appveyor.com/api/projects/status/bp9qt5xfvwd642n3?svg=true
+   :target: https://ci.appveyor.com/project/iminuit/iminuit
+.. image:: https://img.shields.io/pypi/v/iminuit.svg
+   :target: https://pypi.python.org/pypi/iminuit
+.. image:: https://img.shields.io/pypi/dm/iminuit.svg
+   :target: https://pypi.python.org/pypi/iminuit

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -7,6 +7,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 
 STATUS_FAIL, STATUS_SUCCEED = 1, 0
 
+
 def test_notebook(filename):
     t_start = time()
     with open(filename) as f:
@@ -14,7 +15,7 @@ def test_notebook(filename):
         nb = nbformat.read(f, as_version=4)
         ep = ExecutePreprocessor(timeout=1000, kernel_name='python')
         try:
-            ep.preprocess(nb, {'metadata': {'path': 'tutorial/'}})
+            ep.preprocess(nb, {})
         except Exception as e:
             print("{0} [FAILED]\n{1}".format(filename, e))
             return STATUS_FAIL
@@ -22,6 +23,7 @@ def test_notebook(filename):
     t_run = time() - t_start
     print('Execution time for {}: {:.2f} sec'.format(filename, t_run))
     return STATUS_SUCCEED
+
 
 def test_all_notebooks():
     filenames = sorted(glob("tutorial/*.ipynb"))
@@ -37,9 +39,10 @@ def test_all_notebooks():
         status = test_notebook(filename)
         if status == STATUS_FAIL:
             status_total = STATUS_FAIL
-    
+
     print('Total notebook execution status: {}'.format(status_total))
     return status_total
+
 
 if __name__ == '__main__':
     print('Starting notebook tests')


### PR DESCRIPTION
@HDembinski - here's the local fails I got when running from the `sdist` for `test_console` and `test_cython_embedsig`: https://gist.github.com/cdeil/ea3bbea7f5a72b474e1bbba27c24ec42

This should be understood / fixed before making a release.

The first step should be to add a CI test that builds and tests the sdist on travis-ci and appveyor, with Python 2 and 3. That's the main thing that needs to work, not just from the dev folder. Maybe some current builds can be removed.

I see this one:
https://github.com/iminuit/iminuit/blob/3f98a13a2caf908f21c087c4c29044921eafa193/.travis.yml#L25-L26
but it's not even running the tests currently:
https://travis-ci.org/iminuit/iminuit/jobs/400390456#L1043