### PR TITLE
fixing exception report for python 2 and python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ clean:
 
 build: iminuit/_libiminuit.so
 
-iminuit/_libiminuit.so: $(wildcard Minuit/src/*.cxx Minuit/inc/*/*.h iminuit/*.pyx iminuit/*.pxi)
+iminuit/_libiminuit.so: $(wildcard Minuit/src/*.cxx iminuit/*.pyx iminuit/*.pxi)
 	python setup.py build_ext --inplace
 
 test: build

--- a/iminuit/PythonCaller.h
+++ b/iminuit/PythonCaller.h
@@ -3,7 +3,6 @@
 
 #include <stdexcept>
 #include <string>
-#include <cstring> // for std::strlen
 #include <vector>
 #include <Python.h>
 // cannot use this, because cython enforces old api:

--- a/iminuit/PythonCaller.h
+++ b/iminuit/PythonCaller.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <cstring> // for std::strlen
 #include <vector>
 #include <Python.h>
 // cannot use this, because cython enforces old api:
@@ -13,6 +14,8 @@
 
 namespace detail {
 
+// Helper to enable scoped ref counting, which is especially simplifies the
+// code when handling exceptions; the concept is borrowed from Boost.Python
 struct PyHandle {
     PyObject* ptr;
 
@@ -21,14 +24,6 @@ struct PyHandle {
     PyHandle& operator=(PyObject* o) {
         Py_XDECREF(ptr);
         ptr = o;
-        return *this;
-    }
-    PyHandle(const char* s) {
-        ptr = PyUnicode_DecodeASCII(s, std::strlen(s), NULL);
-    }
-    PyHandle& operator=(const char* s) {
-        Py_XDECREF(ptr);
-        ptr = PyUnicode_DecodeASCII(s, std::strlen(s), NULL);
         return *this;
     }
     ~PyHandle() {

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -17,6 +17,7 @@ __all__ = [
     'extract_fix',
     'remove_var',
     'arguments_from_docstring',
+    'format_exception',
 ]
 
 
@@ -301,3 +302,10 @@ def make_func_code(params):
     fc.co_varnames = params
     fc.co_argcount = len(params)
     return fc
+
+def format_exception(etype, evalue, tb):
+    # work around for https://bugs.python.org/issue17413
+    # the issue is not fixed in Python-3.7
+    import traceback
+    s = "".join(traceback.format_tb(tb))
+    return "%s: %s\n%s" % (etype.__name__, evalue, s)


### PR DESCRIPTION
This is now really fixed and works in Python-2.7 and Python-3.7. Tests check that the original error message is included.